### PR TITLE
Get rid of the image border on the left and right side

### DIFF
--- a/src/rqt_image_view/image_view.ui
+++ b/src/rqt_image_view/image_view.ui
@@ -16,7 +16,10 @@
   <property name="windowTitle">
    <string>Image View</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,1,0">
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,1">
+    <property name="margin">
+     <number>0</number>
+    </property>
    <item>
     <widget class="QWidget" name="toolbar_widget" native="true">
      <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -163,6 +166,9 @@
      </property>
      <item>
       <widget class="QScrollArea" name="scrollArea">
+       <property name="frameShape">
+        <enum>QFrame::NoFrame</enum>
+       </property>
        <property name="widgetResizable">
         <bool>true</bool>
        </property>
@@ -200,13 +206,16 @@
              <enum>Qt::ActionsContextMenu</enum>
             </property>
             <property name="frameShape">
-             <enum>QFrame::Box</enum>
+             <enum>QFrame::NoFrame</enum>
             </property>
             <property name="lineWidth">
              <number>1</number>
             </property>
            </widget>
           </item>
+          <property name="margin">
+           <number>0</number>
+          </property>
         </layout>
        </widget>
       </widget>

--- a/src/rqt_image_view/image_view.ui
+++ b/src/rqt_image_view/image_view.ui
@@ -17,9 +17,9 @@
    <string>Image View</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout" stretch="0,1">
-    <property name="margin">
-     <number>0</number>
-    </property>
+   <property name="margin">
+    <number>0</number>
+   </property>
    <item>
     <widget class="QWidget" name="toolbar_widget" native="true">
      <layout class="QVBoxLayout" name="verticalLayout_2">

--- a/src/rqt_image_view/image_view.ui
+++ b/src/rqt_image_view/image_view.ui
@@ -214,7 +214,7 @@
            </widget>
           </item>
           <property name="margin">
-           <number>0</number>
+           <number>1</number>
           </property>
         </layout>
        </widget>


### PR DESCRIPTION
![zero_margin](https://cloud.githubusercontent.com/assets/1334122/25874245/aa40a68a-34df-11e7-8db7-8ba9391a905a.png)

Maybe I'm going too far here, and there should be a size 2 or 4 border?  I have an application that tiles many image views together and I'd like to not waste space, but I also understand the border helps show the images are separate.

![zero_margin_with_scroll](https://cloud.githubusercontent.com/assets/1334122/25874248/ac4096a2-34df-11e7-9666-02b5187920df.png)

I haven't looked into it much but this pr may be contingent on #4 (or even require additional changes in #4) - the image when not in zoom 1 mode zooms itself in even without aspect ratio changes.

Next I'll look into hiding (optionally?) the bar on the bottom- is it used at all?