### PR TITLE
Allow image rotation in 90° steps

### DIFF
--- a/include/rqt_image_view/image_view.h
+++ b/include/rqt_image_view/image_view.h
@@ -107,6 +107,8 @@ protected slots:
 
   virtual void onHideToolbarChanged(bool hide);
 
+  virtual void onRotate();
+
 protected:
 
   virtual void callbackImage(const sensor_msgs::Image::ConstPtr& msg);
@@ -127,6 +129,17 @@ protected:
 
 private:
 
+  enum RotateState {
+    ROTATE_0 = 0,
+    ROTATE_90 = 1,
+    ROTATE_180 = 2,
+    ROTATE_270 = 3,
+
+    ROTATE_STATE_COUNT
+  };
+
+  void syncRotateLabel();
+
   QString arg_topic_name;
   ros::Publisher pub_mouse_left_;
 
@@ -135,6 +148,8 @@ private:
   QAction* hide_toolbar_action_;
 
   int num_gridlines_;
+
+  RotateState rotate_state_;
 };
 
 }

--- a/src/rqt_image_view/image_view.cpp
+++ b/src/rqt_image_view/image_view.cpp
@@ -49,6 +49,7 @@ ImageView::ImageView()
   : rqt_gui_cpp::Plugin()
   , widget_(0)
   , num_gridlines_(0)
+  , rotate_state_(ROTATE_0)
 {
   setObjectName("ImageView");
 }
@@ -99,6 +100,8 @@ void ImageView::initPlugin(qt_gui_cpp::PluginContext& context)
 
   connect(ui_.smooth_image_check_box, SIGNAL(toggled(bool)), ui_.image_frame, SLOT(onSmoothImageChanged(bool)));
 
+  connect(ui_.rotate_push_button, SIGNAL(clicked(bool)), this, SLOT(onRotate()));
+
   hide_toolbar_action_ = new QAction(tr("Hide toolbar"), this);
   hide_toolbar_action_->setCheckable(true);
   ui_.image_frame->addAction(hide_toolbar_action_);
@@ -123,6 +126,7 @@ void ImageView::saveSettings(qt_gui_cpp::Settings& plugin_settings, qt_gui_cpp::
   instance_settings.setValue("mouse_pub_topic", ui_.publish_click_location_topic_line_edit->text());
   instance_settings.setValue("toolbar_hidden", hide_toolbar_action_->isChecked());
   instance_settings.setValue("num_gridlines", ui_.num_gridlines_spin_box->value());
+  instance_settings.setValue("rotate", rotate_state_);
 }
 
 void ImageView::restoreSettings(const qt_gui_cpp::Settings& plugin_settings, const qt_gui_cpp::Settings& instance_settings)
@@ -159,6 +163,11 @@ void ImageView::restoreSettings(const qt_gui_cpp::Settings& plugin_settings, con
 
   bool toolbar_hidden = instance_settings.value("toolbar_hidden", false).toBool();
   hide_toolbar_action_->setChecked(toolbar_hidden);
+
+  rotate_state_ = static_cast<RotateState>(instance_settings.value("rotate", 0).toInt());
+  if(rotate_state_ >= ROTATE_STATE_COUNT)
+    rotate_state_ = ROTATE_0;
+  syncRotateLabel();
 }
 
 void ImageView::updateTopicList()
@@ -387,6 +396,24 @@ void ImageView::onHideToolbarChanged(bool hide)
   ui_.toolbar_widget->setVisible(!hide);
 }
 
+void ImageView::onRotate()
+{
+  rotate_state_ = static_cast<RotateState>((rotate_state_ + 1) % ROTATE_STATE_COUNT);
+  syncRotateLabel();
+}
+
+void ImageView::syncRotateLabel()
+{
+  switch(rotate_state_)
+  {
+    default:
+    case ROTATE_0:   ui_.rotate_push_button->setText("Rotate: 0°"); break;
+    case ROTATE_90:  ui_.rotate_push_button->setText("Rotate: 90°"); break;
+    case ROTATE_180: ui_.rotate_push_button->setText("Rotate: 180°"); break;
+    case ROTATE_270: ui_.rotate_push_button->setText("Rotate: 270°"); break;
+  }
+}
+
 void ImageView::invertPixels(int x, int y)
 {
   // Could do 255-conversion_mat_.at<cv::Vec3b>(cv::Point(x,y))[i], but that doesn't work well on gray
@@ -513,6 +540,34 @@ void ImageView::callbackImage(const sensor_msgs::Image::ConstPtr& msg)
       ui_.image_frame->setImage(QImage());
       return;
     }
+  }
+
+  // Handle rotation
+  switch(rotate_state_)
+  {
+    case ROTATE_90:
+    {
+      cv::Mat tmp;
+      cv::transpose(conversion_mat_, tmp);
+      cv::flip(tmp, conversion_mat_, 0);
+      break;
+    }
+    case ROTATE_180:
+    {
+      cv::Mat tmp;
+      cv::flip(conversion_mat_, tmp, -1);
+      conversion_mat_ = tmp;
+      break;
+    }
+    case ROTATE_270:
+    {
+      cv::Mat tmp;
+      cv::transpose(conversion_mat_, tmp);
+      cv::flip(tmp, conversion_mat_, 1);
+      break;
+    }
+    default:
+      break;
   }
 
   // image must be copied since it uses the conversion_mat_ for storage which is asynchronously overwritten in the next callback invocation

--- a/src/rqt_image_view/image_view.ui
+++ b/src/rqt_image_view/image_view.ui
@@ -164,6 +164,13 @@
          </widget>
         </item>
         <item>
+         <widget class="QPushButton" name="rotate_push_button">
+          <property name="text">
+           <string>Rotate: 0°</string>
+          </property>
+         </widget>
+        </item>
+        <item>
          <spacer name="horizontalSpacer">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>


### PR DESCRIPTION
This is useful for webcams mounted in non-upright orientations. Rather than rotating in the camera driver, it is often better to rotate at the display side, e.g. for cameras mounted on robotic arms that change orientation all the time.