### PR TITLE
Use Python distutils to install the global rqt_image_view executable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,9 +78,6 @@ install(TARGETS ${PROJECT_NAME}
 )
 
 catkin_install_python(PROGRAMS scripts/rqt_image_view
-  DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
-)
-catkin_install_python(PROGRAMS scripts/rqt_image_view
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,8 @@ from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(
     packages=['rqt_image_view'],
-    package_dir={'': 'src'}
+    package_dir={'': 'src'},
+    scripts=['scripts/rqt_image_view']
 )
 
 setup(**d)


### PR DESCRIPTION
Fixes https://github.com/ros-visualization/rqt_image_view/pull/8#issuecomment-375075148 and aligns rqt_image_view with other rqt plugin packages, for example [rqt_logger_level](https://github.com/ros-visualization/rqt_logger_level/blob/master/setup.py).