### PR TITLE
add build dependency on qt5-dev

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -18,6 +18,7 @@
   <build_depend>cv_bridge</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>image_transport</build_depend>
+  <build_depend>qtbase5-dev</build_depend>
   <build_depend>rqt_gui</build_depend>
   <build_depend>rqt_gui_cpp</build_depend>
   <build_depend>sensor_msgs</build_depend>


### PR DESCRIPTION
Required build dependency to fix the builds on [Artful](http://build.ros.org/job/Mbin_uA64__rqt_image_view__ubuntu_artful_amd64__binary/1/) and [Bionic](http://build.ros.org/job/Mbin_uB64__rqt_image_view__ubuntu_bionic_amd64__binary/1/).