### PR TITLE
Added missing: #include <QSet>

### DIFF
--- a/src/rqt_image_view/image_view.cpp
+++ b/src/rqt_image_view/image_view.cpp
@@ -42,6 +42,7 @@
 #include <QFileDialog>
 #include <QMessageBox>
 #include <QPainter>
+#include <QSet>
 
 namespace rqt_image_view {
 


### PR DESCRIPTION
failed to compile. 
See: https://github.com/ros-melodic-arch/ros-melodic-rqt-image-view/issues/1
And #29 : https://github.com/ros-visualization/rqt_image_view/issues/29