### PR TITLE
fix missing include for QSet

### DIFF
--- a/include/rqt_image_view/image_view.h
+++ b/include/rqt_image_view/image_view.h
@@ -49,6 +49,7 @@
 #include <QImage>
 #include <QList>
 #include <QString>
+#include <QSet>
 #include <QSize>
 #include <QWidget>
 


### PR DESCRIPTION
As mentioned in [PR 30](https://github.com/ros-visualization/rqt_image_view/pull/30), fix missing include in header.