### PR TITLE
Fix use-after-free and threading issues

### DIFF
--- a/include/rqt_image_view/image_view.h
+++ b/include/rqt_image_view/image_view.h
@@ -113,9 +113,9 @@ protected slots:
   virtual void onRotateLeft();
   virtual void onRotateRight();
 
-protected:
-
   virtual void callbackImage(const sensor_msgs::Image::ConstPtr& msg);
+
+protected:
 
   virtual void invertPixels(int x, int y);
 
@@ -130,6 +130,9 @@ protected:
   image_transport::Subscriber subscriber_;
 
   cv::Mat conversion_mat_;
+
+Q_SIGNALS:
+  void receivedImage(const sensor_msgs::Image::ConstPtr& msg);
 
 private:
 

--- a/include/rqt_image_view/ratio_layouted_frame.h
+++ b/include/rqt_image_view/ratio_layouted_frame.h
@@ -80,8 +80,6 @@ public:
 
 signals:
 
-  void delayed_update();
-
   void mouseLeft(int x, int y);
 
 protected slots:
@@ -105,7 +103,6 @@ private:
   QSize aspect_ratio_;
 
   QImage qimage_;
-  mutable QMutex qimage_mutex_;
 
   bool smoothImage_;
 };

--- a/src/rqt_image_view/image_view.cpp
+++ b/src/rqt_image_view/image_view.cpp
@@ -557,6 +557,11 @@ void ImageView::overlayGrid()
 
 void ImageView::callbackImage(const sensor_msgs::Image::ConstPtr& msg)
 {
+  // Make sure conversion_mat_ does not point to some old data (or, in the case
+  // of cv_bridge::toCvShare() to an old message). This is important in the
+  // manual conversion path below.
+  conversion_mat_ = cv::Mat();
+
   try
   {
     // First let cv_bridge do its magic
@@ -627,6 +632,7 @@ void ImageView::callbackImage(const sensor_msgs::Image::ConstPtr& msg)
     {
       cv::Mat tmp;
       cv::transpose(conversion_mat_, tmp);
+      conversion_mat_ = cv::Mat(); // conversion_mat_ might point to const msg
       cv::flip(tmp, conversion_mat_, 1);
       break;
     }
@@ -641,6 +647,7 @@ void ImageView::callbackImage(const sensor_msgs::Image::ConstPtr& msg)
     {
       cv::Mat tmp;
       cv::transpose(conversion_mat_, tmp);
+      conversion_mat_ = cv::Mat(); // conversion_mat_ might point to const msg
       cv::flip(tmp, conversion_mat_, 0);
       break;
     }

--- a/src/rqt_image_view/ratio_layouted_frame.cpp
+++ b/src/rqt_image_view/ratio_layouted_frame.cpp
@@ -43,7 +43,6 @@ RatioLayoutedFrame::RatioLayoutedFrame(QWidget* parent, Qt::WindowFlags flags)
   , aspect_ratio_(4, 3)
   , smoothImage_(false)
 {
-  connect(this, SIGNAL(delayed_update()), this, SLOT(update()), Qt::QueuedConnection);
 }
 
 RatioLayoutedFrame::~RatioLayoutedFrame()
@@ -58,19 +57,15 @@ const QImage& RatioLayoutedFrame::getImage() const
 QImage RatioLayoutedFrame::getImageCopy() const
 {
   QImage img;
-  qimage_mutex_.lock();
   img = qimage_.copy();
-  qimage_mutex_.unlock();
   return img;
 }
 
 void RatioLayoutedFrame::setImage(const QImage& image)//, QMutex* image_mutex)
 {
-  qimage_mutex_.lock();
   qimage_ = image.copy();
   setAspectRatio(qimage_.width(), qimage_.height());
-  qimage_mutex_.unlock();
-  emit delayed_update();
+  update();
 }
 
 void RatioLayoutedFrame::resizeToFitAspectRatio()
@@ -126,7 +121,6 @@ void RatioLayoutedFrame::setInnerFrameMinimumSize(const QSize& size)
   QSize new_size = size;
   new_size += QSize(2 * border, 2 * border);
   setMinimumSize(new_size);
-  emit delayed_update();
 }
 
 void RatioLayoutedFrame::setInnerFrameMaximumSize(const QSize& size)
@@ -135,7 +129,6 @@ void RatioLayoutedFrame::setInnerFrameMaximumSize(const QSize& size)
   QSize new_size = size;
   new_size += QSize(2 * border, 2 * border);
   setMaximumSize(new_size);
-  emit delayed_update();
 }
 
 void RatioLayoutedFrame::setInnerFrameFixedSize(const QSize& size)
@@ -156,7 +149,6 @@ void RatioLayoutedFrame::setAspectRatio(unsigned short width, unsigned short hei
 void RatioLayoutedFrame::paintEvent(QPaintEvent* event)
 {
   QPainter painter(this);
-  qimage_mutex_.lock();
   if (!qimage_.isNull())
   {
     resizeToFitAspectRatio();
@@ -182,7 +174,6 @@ void RatioLayoutedFrame::paintEvent(QPaintEvent* event)
     painter.setBrush(gradient);
     painter.drawRect(0, 0, frameRect().width() + 1, frameRect().height() + 1);
   }
-  qimage_mutex_.unlock();
 }
 
 int RatioLayoutedFrame::greatestCommonDivisor(int a, int b)


### PR DESCRIPTION
This PR fixes two sources of rqt_image_view crashes:

1) Use-after-free involving `conversion_mat_`, especially on topic changes with different image encodings,
2) Calling of non-thread-safe Qt methods inside `imageCallback()`, which is executed in the ROS thread. This is mitigated by moving `imageCallback()` to the main thread, which also removes a lot of locking code (and I'm actually not sure the locking was sufficient).

See individual commits for details.