### PR TITLE
Avoid redeclaring parameter

### DIFF
--- a/src/rqt_image_view/image_view.cpp
+++ b/src/rqt_image_view/image_view.cpp
@@ -316,6 +316,9 @@ void ImageView::onTopicChanged(int index)
     image_transport::ImageTransport it(node_);
     const image_transport::TransportHints hints(node_.get(), transport.toStdString());
     try {
+      if (node_->has_parameter("mode")) {
+        node_->undeclare_parameter("mode");
+      }
       subscriber_ = it.subscribe(topic.toStdString(), 1, &ImageView::callbackImage, this, &hints);
       qDebug("ImageView::onTopicChanged() to topic '%s' with transport '%s'", topic.toStdString().c_str(), subscriber_.getTransport().c_str());
     } catch (image_transport::TransportLoadException& e) {


### PR DESCRIPTION
When compressed image is subscribed, mode is declared as parameter.
https://github.com/ros-perception/image_transport_plugins/blob/0565f23dc955fa2d56cffcfebc63de5a97cd005f/compressed_image_transport/src/compressed_subscriber.cpp#L76
This causes an exception as below when a topic of compressed image is chosen again as a subscription topic.
`terminate called after throwing an instance of 'rclcpp::exceptions::ParameterAlreadyDeclaredException'
  what():  parameter 'mode' has already been declared
`