### PR TITLE
Add interchangeable qos policies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ include_directories(
   ${rqt_image_view_INCLUDE_DIRECTORIES}
 )
 
-add_library(${PROJECT_NAME}
+add_library(${PROJECT_NAME} SHARED
   ${rqt_image_view_SRCS}
   ${rqt_image_view_MOCS}
   ${rqt_image_view_UIS_H}

--- a/src/rqt_image_view/image_view.cpp
+++ b/src/rqt_image_view/image_view.cpp
@@ -316,7 +316,20 @@ void ImageView::onTopicChanged(int index)
     image_transport::ImageTransport it(node_);
     const image_transport::TransportHints hints(node_.get(), transport.toStdString());
     try {
-      subscriber_ = it.subscribe(topic.toStdString(), 1, &ImageView::callbackImage, this, &hints);
+       std::vector<rclcpp::TopicEndpointInfo> endpoints = node_->get_publishers_info_by_topic(topic.toStdString());
+       if(endpoints.empty())
+       {
+         rclcpp::QoS topic_qos(1);
+         subscriber_ = image_transport::create_subscription(node_.get(),topic.toStdString(),std::bind(&ImageView::callbackImage,this,std::placeholders::_1),hints.getTransport(),
+      topic_qos.get_rmw_qos_profile());
+       }
+       else
+       {
+         rclcpp::QoS topic_qos = endpoints.front().qos_profile();
+         subscriber_ = image_transport::create_subscription(node_.get(),topic.toStdString(),std::bind(&ImageView::callbackImage,this,std::placeholders::_1),hints.getTransport(),
+      topic_qos.get_rmw_qos_profile());
+       }  
+
       qDebug("ImageView::onTopicChanged() to topic '%s' with transport '%s'", topic.toStdString().c_str(), subscriber_.getTransport().c_str());
     } catch (image_transport::TransportLoadException& e) {
       QMessageBox::warning(widget_, tr("Loading image transport plugin failed"), e.what());


### PR DESCRIPTION
This PR allows automatic configuration of subscriber QoS policies. This is important because on some networks, compressed image topics may have specific QoS profile. This PR tries to find the QoS available and sets it to default if not. It has been tested on multiple custom qos profiles and has shown to work very well without errors.