### PR TITLE
[FIX] add missing QComboBox to ui

### DIFF
--- a/src/rqt_image_view/image_view.ui
+++ b/src/rqt_image_view/image_view.ui
@@ -198,6 +198,13 @@
          </widget>
         </item>
         <item>
+         <widget class="QComboBox" name="color_scheme_combo_box">
+          <property name="sizeAdjustPolicy">
+           <enum>QComboBox::AdjustToContents</enum>
+          </property>
+         </widget>
+        </item>
+        <item>
          <spacer name="horizontalSpacer">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>


### PR DESCRIPTION
fixing issue (https://github.com/ros-visualization/rqt_image_view/issues/65) the missing entry is added to the image_view.ui