### PR TITLE
[ROS-O] no longer use c++11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,6 @@ cmake_minimum_required(VERSION 3.0.2)
 
 project(rqt_image_view)
 
-add_compile_options(-std=c++11)
-
 # Load catkin and all dependencies required for this package
 find_package(catkin REQUIRED COMPONENTS rqt_gui rqt_gui_cpp image_transport sensor_msgs geometry_msgs cv_bridge)
 

--- a/src/rqt_image_view/image_view.cpp
+++ b/src/rqt_image_view/image_view.cpp
@@ -32,7 +32,7 @@
 
 #include <rqt_image_view/image_view.h>
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <ros/master.h>
 #include <sensor_msgs/image_encodings.h>
 


### PR DESCRIPTION
forcing the old standard breaks with most builds of a current lib4cxx (which requires c++17).