### PR TITLE
include cv_bridge.hpp instead of cv_bridge.h

### DIFF
--- a/src/rqt_image_view/image_view.cpp
+++ b/src/rqt_image_view/image_view.cpp
@@ -35,7 +35,7 @@
 #include <pluginlib/class_list_macros.hpp>
 #include <sensor_msgs/image_encodings.hpp>
 
-#include <cv_bridge/cv_bridge.h>
+#include <cv_bridge/cv_bridge.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
 
 #include <QFileDialog>


### PR DESCRIPTION
cv_bridge.h was removed recently https://github.com/ros-perception/vision_opencv/commit/f2fa8b50f46ea0cda82e60b3c538d14e057199ca