### PR TITLE
update plugin.h to plugin.hpp

### DIFF
--- a/include/rqt_image_view/image_view.h
+++ b/include/rqt_image_view/image_view.h
@@ -33,7 +33,7 @@
 #ifndef rqt_image_view__ImageView_H
 #define rqt_image_view__ImageView_H
 
-#include <rqt_gui_cpp/plugin.h>
+#include <rqt_gui_cpp/plugin.hpp>
 
 #include <ui_image_view.h>
 


### PR DESCRIPTION
The change is necessary because plugin.h will be deprecated and replaced by plugin.hpp.