### PR TITLE
Porting the color scheme for 32FC1 encoding from Noetic

### DIFF
--- a/include/rqt_image_view/image_view.hpp
+++ b/include/rqt_image_view/image_view.hpp
@@ -80,8 +80,6 @@ public:
 protected slots:
   virtual void updateTopicList();
 
-  virtual void setColorSchemeList();
-
 protected:
   virtual QSet<QString> getTopics(
     const QSet<QString> & message_types,

--- a/include/rqt_image_view/image_view.hpp
+++ b/include/rqt_image_view/image_view.hpp
@@ -80,6 +80,8 @@ public:
 protected slots:
   virtual void updateTopicList();
 
+  virtual void setColorSchemeList();
+
 protected:
   virtual QSet<QString> getTopics(
     const QSet<QString> & message_types,

--- a/src/rqt_image_view/image_view.cpp
+++ b/src/rqt_image_view/image_view.cpp
@@ -622,6 +622,8 @@ void ImageView::callbackImage(const sensor_msgs::msg::Image::ConstSharedPtr & ms
 
         const auto color_scheme_index = ui_.color_scheme_combo_box->currentIndex();
         const auto color_scheme = ui_.color_scheme_combo_box->itemData(color_scheme_index).toInt();
+
+        // convert the scaled image to the selected color scheme; Gray (color scheme = -1) being a special case
         if (color_scheme == -1) {
           cv::cvtColor(img_scaled_8u, conversion_mat_, CV_GRAY2RGB);
         } else {

--- a/src/rqt_image_view/image_view.cpp
+++ b/src/rqt_image_view/image_view.cpp
@@ -46,6 +46,24 @@
 
 namespace rqt_image_view
 {
+
+static const std::map<std::string, int> COLOR_SCHEME_MAP
+{
+  { "Gray", -1 },  // Special case: no color map
+  { "Autumn", cv::COLORMAP_AUTUMN },
+  { "Bone", cv::COLORMAP_BONE },
+  { "Cool", cv::COLORMAP_COOL },
+  { "Hot", cv::COLORMAP_HOT },
+  { "Hsv", cv::COLORMAP_HSV },
+  { "Jet", cv::COLORMAP_JET },
+  { "Ocean", cv::COLORMAP_OCEAN },
+  { "Pink", cv::COLORMAP_PINK },
+  { "Rainbow", cv::COLORMAP_RAINBOW },
+  { "Spring", cv::COLORMAP_SPRING },
+  { "Summer", cv::COLORMAP_SUMMER },
+  { "Winter", cv::COLORMAP_WINTER }
+};
+
 ImageView::ImageView()
 : rqt_gui_cpp::Plugin()
   , widget_(0)
@@ -66,7 +84,12 @@ void ImageView::initPlugin(qt_gui_cpp::PluginContext & context)
   }
   context.addWidget(widget_);
 
-  setColorSchemeList();
+  // set the color scheme list in the UI
+  for (const auto& kv : COLOR_SCHEME_MAP)
+  {
+    ui_.color_scheme_combo_box->addItem(QString::fromStdString(kv.first), QVariant(kv.second));
+  }
+
   // set default color scheme to Gray
   ui_.color_scheme_combo_box->setCurrentIndex(ui_.color_scheme_combo_box->findText("Gray"));
   ui_.color_scheme_combo_box->setCurrentText("Gray");
@@ -208,31 +231,6 @@ void ImageView::restoreSettings(
   // set default color scheme to Gray
   ui_.color_scheme_combo_box->setCurrentIndex(ui_.color_scheme_combo_box->findText("Gray"));
   ui_.color_scheme_combo_box->setCurrentText("Gray");
-}
-
-void ImageView::setColorSchemeList()
-{
-  static const std::map<std::string, int> COLOR_SCHEME_MAP
-  {
-    { "Gray", -1 },  // Special case: no color map
-    { "Autumn", cv::COLORMAP_AUTUMN },
-    { "Bone", cv::COLORMAP_BONE },
-    { "Cool", cv::COLORMAP_COOL },
-    { "Hot", cv::COLORMAP_HOT },
-    { "Hsv", cv::COLORMAP_HSV },
-    { "Jet", cv::COLORMAP_JET },
-    { "Ocean", cv::COLORMAP_OCEAN },
-    { "Pink", cv::COLORMAP_PINK },
-    { "Rainbow", cv::COLORMAP_RAINBOW },
-    { "Spring", cv::COLORMAP_SPRING },
-    { "Summer", cv::COLORMAP_SUMMER },
-    { "Winter", cv::COLORMAP_WINTER }
-  };
-
-  for (const auto& kv : COLOR_SCHEME_MAP)
-  {
-    ui_.color_scheme_combo_box->addItem(QString::fromStdString(kv.first), QVariant(kv.second));
-  }
 }
 
 void ImageView::updateTopicList()

--- a/src/rqt_image_view/image_view.cpp
+++ b/src/rqt_image_view/image_view.cpp
@@ -67,7 +67,9 @@ void ImageView::initPlugin(qt_gui_cpp::PluginContext & context)
   context.addWidget(widget_);
 
   setColorSchemeList();
+  // set default color scheme to Gray
   ui_.color_scheme_combo_box->setCurrentIndex(ui_.color_scheme_combo_box->findText("Gray"));
+  ui_.color_scheme_combo_box->setCurrentText("Gray");
 
   updateTopicList();
   ui_.topics_combo_box->setCurrentIndex(ui_.topics_combo_box->findText(""));
@@ -203,9 +205,9 @@ void ImageView::restoreSettings(
   }
   syncRotateLabel();
 
-  int color_scheme = instance_settings.value("color_scheme",
-      ui_.color_scheme_combo_box->currentIndex()).toInt();
-  ui_.color_scheme_combo_box->setCurrentIndex(color_scheme);
+  // set default color scheme to Gray
+  ui_.color_scheme_combo_box->setCurrentIndex(ui_.color_scheme_combo_box->findText("Gray"));
+  ui_.color_scheme_combo_box->setCurrentText("Gray");
 }
 
 void ImageView::setColorSchemeList()

--- a/src/rqt_image_view/image_view.cpp
+++ b/src/rqt_image_view/image_view.cpp
@@ -62,7 +62,7 @@ static const std::map<std::string, int> COLOR_SCHEME_MAP
   { "Spring", cv::COLORMAP_SPRING },
   { "Summer", cv::COLORMAP_SUMMER },
   { "Winter", cv::COLORMAP_WINTER }
-};
+};  // following OpenCV options https://docs.opencv.org/4.x/d3/d50/group__imgproc__colormap.html
 
 ImageView::ImageView()
 : rqt_gui_cpp::Plugin()

--- a/src/rqt_image_view/image_view.cpp
+++ b/src/rqt_image_view/image_view.cpp
@@ -618,7 +618,6 @@ void ImageView::callbackImage(const sensor_msgs::msg::Image::ConstSharedPtr & ms
         }
         cv::Mat img_scaled_8u;
         cv::Mat(cv_ptr->image - min).convertTo(img_scaled_8u, CV_8UC1, 255. / (max - min));
-        // cv::cvtColor(img_scaled_8u, conversion_mat_, CV_GRAY2RGB);
 
         const auto color_scheme_index = ui_.color_scheme_combo_box->currentIndex();
         const auto color_scheme = ui_.color_scheme_combo_box->itemData(color_scheme_index).toInt();

--- a/src/rqt_image_view/image_view.cpp
+++ b/src/rqt_image_view/image_view.cpp
@@ -49,19 +49,19 @@ namespace rqt_image_view
 
 static const std::map<std::string, int> COLOR_SCHEME_MAP
 {
-  { "Gray", -1 },  // Special case: no color map
-  { "Autumn", cv::COLORMAP_AUTUMN },
-  { "Bone", cv::COLORMAP_BONE },
-  { "Cool", cv::COLORMAP_COOL },
-  { "Hot", cv::COLORMAP_HOT },
-  { "Hsv", cv::COLORMAP_HSV },
-  { "Jet", cv::COLORMAP_JET },
-  { "Ocean", cv::COLORMAP_OCEAN },
-  { "Pink", cv::COLORMAP_PINK },
-  { "Rainbow", cv::COLORMAP_RAINBOW },
-  { "Spring", cv::COLORMAP_SPRING },
-  { "Summer", cv::COLORMAP_SUMMER },
-  { "Winter", cv::COLORMAP_WINTER }
+  {"Gray", -1},  // Special case: no color map
+  {"Autumn", cv::COLORMAP_AUTUMN},
+  {"Bone", cv::COLORMAP_BONE},
+  {"Cool", cv::COLORMAP_COOL},
+  {"Hot", cv::COLORMAP_HOT},
+  {"Hsv", cv::COLORMAP_HSV},
+  {"Jet", cv::COLORMAP_JET},
+  {"Ocean", cv::COLORMAP_OCEAN},
+  {"Pink", cv::COLORMAP_PINK},
+  {"Rainbow", cv::COLORMAP_RAINBOW},
+  {"Spring", cv::COLORMAP_SPRING},
+  {"Summer", cv::COLORMAP_SUMMER},
+  {"Winter", cv::COLORMAP_WINTER}
 };  // following OpenCV options https://docs.opencv.org/4.x/d3/d50/group__imgproc__colormap.html
 
 ImageView::ImageView()
@@ -85,8 +85,7 @@ void ImageView::initPlugin(qt_gui_cpp::PluginContext & context)
   context.addWidget(widget_);
 
   // set the color scheme list in the UI
-  for (const auto& kv : COLOR_SCHEME_MAP)
-  {
+  for (const auto & kv : COLOR_SCHEME_MAP) {
     ui_.color_scheme_combo_box->addItem(QString::fromStdString(kv.first), QVariant(kv.second));
   }
 

--- a/src/rqt_image_view/image_view.cpp
+++ b/src/rqt_image_view/image_view.cpp
@@ -621,7 +621,8 @@ void ImageView::callbackImage(const sensor_msgs::msg::Image::ConstSharedPtr & ms
         const auto color_scheme_index = ui_.color_scheme_combo_box->currentIndex();
         const auto color_scheme = ui_.color_scheme_combo_box->itemData(color_scheme_index).toInt();
 
-        // convert the scaled image to the selected color scheme; Gray (color scheme = -1) being a special case
+        // convert the scaled image to the selected color scheme;
+        // "Gray" (color scheme = -1) being a special case
         if (color_scheme == -1) {
           cv::cvtColor(img_scaled_8u, conversion_mat_, CV_GRAY2RGB);
         } else {

--- a/src/rqt_image_view/image_view.cpp
+++ b/src/rqt_image_view/image_view.cpp
@@ -66,6 +66,9 @@ void ImageView::initPlugin(qt_gui_cpp::PluginContext & context)
   }
   context.addWidget(widget_);
 
+  setColorSchemeList();
+  ui_.color_scheme_combo_box->setCurrentIndex(ui_.color_scheme_combo_box->findText("Gray"));
+
   updateTopicList();
   ui_.topics_combo_box->setCurrentIndex(ui_.topics_combo_box->findText(""));
   connect(ui_.topics_combo_box, SIGNAL(currentIndexChanged(int)), this, SLOT(onTopicChanged(int)));
@@ -203,6 +206,31 @@ void ImageView::restoreSettings(
   int color_scheme = instance_settings.value("color_scheme",
       ui_.color_scheme_combo_box->currentIndex()).toInt();
   ui_.color_scheme_combo_box->setCurrentIndex(color_scheme);
+}
+
+void ImageView::setColorSchemeList()
+{
+  static const std::map<std::string, int> COLOR_SCHEME_MAP
+  {
+    { "Gray", -1 },  // Special case: no color map
+    { "Autumn", cv::COLORMAP_AUTUMN },
+    { "Bone", cv::COLORMAP_BONE },
+    { "Cool", cv::COLORMAP_COOL },
+    { "Hot", cv::COLORMAP_HOT },
+    { "Hsv", cv::COLORMAP_HSV },
+    { "Jet", cv::COLORMAP_JET },
+    { "Ocean", cv::COLORMAP_OCEAN },
+    { "Pink", cv::COLORMAP_PINK },
+    { "Rainbow", cv::COLORMAP_RAINBOW },
+    { "Spring", cv::COLORMAP_SPRING },
+    { "Summer", cv::COLORMAP_SUMMER },
+    { "Winter", cv::COLORMAP_WINTER }
+  };
+
+  for (const auto& kv : COLOR_SCHEME_MAP)
+  {
+    ui_.color_scheme_combo_box->addItem(QString::fromStdString(kv.first), QVariant(kv.second));
+  }
 }
 
 void ImageView::updateTopicList()
@@ -590,7 +618,17 @@ void ImageView::callbackImage(const sensor_msgs::msg::Image::ConstSharedPtr & ms
         }
         cv::Mat img_scaled_8u;
         cv::Mat(cv_ptr->image - min).convertTo(img_scaled_8u, CV_8UC1, 255. / (max - min));
-        cv::cvtColor(img_scaled_8u, conversion_mat_, CV_GRAY2RGB);
+        // cv::cvtColor(img_scaled_8u, conversion_mat_, CV_GRAY2RGB);
+
+        const auto color_scheme_index = ui_.color_scheme_combo_box->currentIndex();
+        const auto color_scheme = ui_.color_scheme_combo_box->itemData(color_scheme_index).toInt();
+        if (color_scheme == -1) {
+          cv::cvtColor(img_scaled_8u, conversion_mat_, CV_GRAY2RGB);
+        } else {
+          cv::Mat img_color_scheme;
+          cv::applyColorMap(img_scaled_8u, img_color_scheme, color_scheme);
+          cv::cvtColor(img_color_scheme, conversion_mat_, CV_BGR2RGB);
+        }
       } else {
         qWarning("ImageView.callback_image() could not convert image from '%s' to 'rgb8' (%s)",
             msg->encoding.c_str(), e.what());


### PR DESCRIPTION
It seems the porting of the colormap for 1 channel data has been forgotten during the porting from ROS1 to ROS2. The button was still there in the UI but the backend code was missing. 

This PR is mainly a copy paste from the noetic-devel branch. The only modification is ensuring that the default is 'gray'.  I didn't experienced any issues while testing the code from rosbag data. 

Below a picture of how it looks like:
![image](https://github.com/user-attachments/assets/b9337b10-df73-4ad5-b6b4-3463589c13dd)
