### PR TITLE
Support Qt6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,8 +23,16 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 find_package(rclcpp REQUIRED)
-find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Widgets)
-find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Widgets Core)
+# Avoid find_package(QT NAMES Qt6 Qt5 ...) due to CMake's default ascending path resolution
+find_package(Qt6 QUIET COMPONENTS Widgets Core)
+if(Qt6_FOUND)
+  set(QT_VERSION_MAJOR 6)
+else()
+  find_package(Qt5 REQUIRED COMPONENTS Widgets Core)
+  set(QT_VERSION_MAJOR 5)
+endif()
+set(QT_VERSION "${Qt${QT_VERSION_MAJOR}_VERSION}")
+
 find_package(qt_gui_cpp REQUIRED)
 find_package(rqt_gui_cpp REQUIRED)
 find_package(image_transport REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,14 +23,17 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 find_package(rclcpp REQUIRED)
+find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Widgets)
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Widgets Core)
 find_package(qt_gui_cpp REQUIRED)
 find_package(rqt_gui_cpp REQUIRED)
 find_package(image_transport REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(cv_bridge REQUIRED)
-find_package(Qt5Widgets REQUIRED)
 find_package(ament_cmake_python REQUIRED)
+
+message("Using Qt ${QT_VERSION_MAJOR}")
 
 set(rqt_image_view_SRCS
   src/rqt_image_view/image_view.cpp
@@ -46,15 +49,21 @@ set(rqt_image_view_UIS
   src/rqt_image_view/image_view.ui
 )
 
-qt5_wrap_cpp(rqt_image_view_MOCS ${rqt_image_view_HDRS})
-
-qt5_wrap_ui(rqt_image_view_UIS_H ${rqt_image_view_UIS})
+if (${QT_VERSION_MAJOR} GREATER "5")
+  qt_standard_project_setup()
+  qt_wrap_cpp(rqt_image_view_MOCS ${rqt_image_view_HDRS})
+  qt_wrap_ui(rqt_image_view_UIS_H ${rqt_image_view_UIS})
+else()
+  qt5_wrap_cpp(rqt_image_view_MOCS ${rqt_image_view_HDRS})
+  qt5_wrap_ui(rqt_image_view_UIS_H ${rqt_image_view_UIS})
+endif()
 
 add_library(${PROJECT_NAME} SHARED
   ${rqt_image_view_SRCS}
   ${rqt_image_view_MOCS}
   ${rqt_image_view_UIS_H}
 )
+set_property(TARGET ${PROJECT_NAME} PROPERTY AUTOMOC 1)
 
 target_include_directories(${PROJECT_NAME} PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
@@ -67,10 +76,11 @@ target_link_libraries(${PROJECT_NAME} PUBLIC
   image_transport::image_transport
   ${sensor_msgs_TARGETS}
   ${geometry_msgs_TARGETS}
-  Qt5::Widgets
+  Qt${QT_VERSION_MAJOR}::Widgets
+PRIVATE
+  Qt${QT_VERSION_MAJOR}::Core
+  cv_bridge::cv_bridge
 )
-target_link_libraries(${PROJECT_NAME} PRIVATE
-  cv_bridge::cv_bridge)
 
 install(
   TARGETS ${PROJECT_NAME}

--- a/include/rqt_image_view/image_view.hpp
+++ b/include/rqt_image_view/image_view.hpp
@@ -51,6 +51,7 @@
 #include <QAction>  // NOLINT
 #include <QImage>  // NOLINT
 #include <QList>  // NOLINT
+#include <QObject>  // NOLINT
 #include <QString>  // NOLINT
 #include <QSet>  // NOLINT
 #include <QSize>  // NOLINT

--- a/include/rqt_image_view/ratio_layouted_frame.hpp
+++ b/include/rqt_image_view/ratio_layouted_frame.hpp
@@ -38,6 +38,7 @@
 #include <QLayout>
 #include <QLayoutItem>
 #include <QMutex>
+#include <QObject>
 #include <QPainter>
 #include <QRect>
 #include <QSize>

--- a/package.xml
+++ b/package.xml
@@ -19,7 +19,7 @@
   <build_depend>cv_bridge</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>image_transport</build_depend>
-  <build_depend>qtbase5-dev</build_depend>
+  <build_depend>qt6-base-dev</build_depend>
   <build_depend>rqt_gui</build_depend>
   <build_depend>rqt_gui_cpp</build_depend>
   <build_depend>qt_gui_cpp</build_depend>

--- a/src/rqt_image_view/image_view.cpp
+++ b/src/rqt_image_view/image_view.cpp
@@ -43,6 +43,7 @@
 #include <QFileDialog>  // NOLINT
 #include <QMessageBox>  // NOLINT
 #include <QPainter>  // NOLINT
+#include <QRegularExpressionValidator>  // NOLINT
 
 namespace rqt_image_view
 {
@@ -121,8 +122,8 @@ void ImageView::initPlugin(qt_gui_cpp::PluginContext & context)
   ui_.image_frame->setOuterLayout(ui_.image_layout);
 
   // see http://www.ros.org/wiki/ROS/Concepts#Names.Valid_Names (but also accept an empty field)
-  QRegExp rx("([a-zA-Z/][a-zA-Z0-9_/]*)?");
-  ui_.publish_click_location_topic_line_edit->setValidator(new QRegExpValidator(rx, this));
+  QRegularExpression  rx("([a-zA-Z/][a-zA-Z0-9_/]*)?");
+  ui_.publish_click_location_topic_line_edit->setValidator(new QRegularExpressionValidator(rx, this));
   connect(ui_.publish_click_location_check_box, SIGNAL(toggled(bool)), this,
       SLOT(onMousePublish(bool)));
   connect(ui_.image_frame, SIGNAL(mouseLeft(int,int)), this, SLOT(onMouseLeft(int,int)));  // NOLINT


### PR DESCRIPTION
Related with https://github.com/ros2/ros2/issues/1798

I'm getting this error: 

```
RosPluginlibPluginProvider::load_explicit_type(rqt_image_view/ImageView) could not load library (Failed to load library /home/ahcorde/ros2_rolling/install_qt6/lib/rqt_image_view/librqt_image_view.so. Make sure that you are calling the PLUGINLIB_EXPORT_CLASS macro in the library code, and that names are consistent between this macro and your XML. Error string: Could not load library dlopen error: /home/ahcorde/ros2_rolling/install_qt6/lib/rqt_image_view/librqt_image_view.so: undefined symbol: _ZN6QFrame16staticMetaObjectE, at /home/ahcorde/ros2_rolling/src/ros2/rcutils/src/shared_library.c:96)
PluginManager._load_plugin_restore()
PluginManager._load_plugin() could not load plugin "['rqt_image_view/ImageView']": RosPluginlibPluginProvider.load() could not load plugin "['rqt_image_view/ImageView']"
Warning: class_loader.ClassLoader: SEVERE WARNING!!! Attempting to unload library while objects created by this loader exist in the heap! You should delete your objects before attempting to unload the library or destroying the ClassLoader. The library will NOT be unloaded.
         at line 127 in /home/ahcorde/ros2_rolling/src/ros/class_loader/src/class_loader.cpp
```