### PR TITLE
Make compatible with Qt5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,17 +23,11 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 find_package(rclcpp REQUIRED)
-# Avoid find_package(QT NAMES Qt6 Qt5 ...) due to CMake's default ascending path resolution
-find_package(Qt6 QUIET COMPONENTS Widgets Core)
-if(Qt6_FOUND)
-  set(QT_VERSION_MAJOR 6)
-else()
-  find_package(Qt5 REQUIRED COMPONENTS Widgets Core)
-  set(QT_VERSION_MAJOR 5)
-endif()
-set(QT_VERSION "${Qt${QT_VERSION_MAJOR}_VERSION}")
 
 find_package(qt_gui_cpp REQUIRED)
+set(QT_VERSION_MAJOR "${qt_gui_cpp_USE_QT_MAJOR_VERSION}")
+find_package(Qt${qt_gui_cpp_USE_QT_MAJOR_VERSION} REQUIRED COMPONENTS Widgets Core)
+
 find_package(rqt_gui_cpp REQUIRED)
 find_package(image_transport REQUIRED)
 find_package(sensor_msgs REQUIRED)
@@ -58,7 +52,6 @@ set(rqt_image_view_UIS
 )
 
 if (${QT_VERSION_MAJOR} GREATER "5")
-  qt_standard_project_setup()
   qt_wrap_cpp(rqt_image_view_MOCS ${rqt_image_view_HDRS})
   qt_wrap_ui(rqt_image_view_UIS_H ${rqt_image_view_UIS})
 else()

--- a/package.xml
+++ b/package.xml
@@ -19,7 +19,8 @@
   <build_depend>cv_bridge</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>image_transport</build_depend>
-  <build_depend>qt6-base-dev</build_depend>
+  <build_depend>qt-base-dev</build_depend>
+  <build_depend>libqtwidgets</build_depend>
   <build_depend>rqt_gui</build_depend>
   <build_depend>rqt_gui_cpp</build_depend>
   <build_depend>qt_gui_cpp</build_depend>
@@ -28,6 +29,8 @@
   <exec_depend>cv_bridge</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>image_transport</exec_depend>
+  <exec_depend>qt-base-dev</exec_depend>
+  <exec_depend>libqtwidgets</exec_depend>
   <exec_depend>rqt_gui</exec_depend>
   <exec_depend>rqt_gui_cpp</exec_depend>
   <exec_depend>qt_gui_cpp</exec_depend>


### PR DESCRIPTION
This should solve the rqt_image_view regression.

* Use Qt major version decided by qt_gui_cpp (which itself gets it from python_qt_binding)
* Remove call to non-existent method `qt_standard_project_setup`
* Use rosdep keys that select between Qt5 and Qt6 on different platforms.