### PR TITLE
Fix image artifacts when enabling `zoom1`

### DIFF
--- a/src/rqt_image_view/image_view.ui
+++ b/src/rqt_image_view/image_view.ui
@@ -272,7 +272,7 @@
              <enum>QFrame::NoFrame</enum>
             </property>
             <property name="lineWidth">
-             <number>1</number>
+             <number>0</number>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
Fix https://github.com/ros-visualization/rqt_image_view/issues/85

What this fixes: the scaling artefacts are now gone because a true 1-to-1 pixel mapping occurs from image message to the display, without scaling twice in between.

What this _probably_ does not fix: the frame size still isn't handled correctly, it just got hidden because  got set to zero. I'm afraid it will arise again when people including this code set  to a non-zero value.