### PR TITLE
Support linear response images via sRGB OETF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,6 +123,7 @@ ament_export_targets(${PROJECT_NAME})
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
+  add_subdirectory(test)
 endif()
 
 ament_package()

--- a/include/rqt_image_view/linear_to_srgb.hpp
+++ b/include/rqt_image_view/linear_to_srgb.hpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026, Arne Baeyens
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef RQT_IMAGE_VIEW__LINEAR_TO_SRGB_HPP_
+#define RQT_IMAGE_VIEW__LINEAR_TO_SRGB_HPP_
+
+#include <algorithm>
+#include <cmath>
+
+#include <opencv2/core/core.hpp>
+
+namespace rqt_image_view
+{
+/**
+ * Create a LUT with the sRGB OETF (linear -> sRGB encoding)
+ */
+inline cv::Mat buildLinearToSrgbLut()
+{
+  cv::Mat lut(1, 256, CV_8UC1);
+  uchar * data = lut.ptr<uchar>();
+  for (int i = 0; i < 256; ++i) {
+    const double linear = static_cast<double>(i) / 255.0;
+    const double encoded = linear <= 0.0031308 ?
+      12.92 * linear :
+      1.055 * std::pow(linear, 1.0 / 2.4) - 0.055;
+    const int v = std::clamp(static_cast<int>(std::lround(encoded * 255.0)), 0, 255);
+    data[i] = static_cast<uchar>(v);
+  }
+  return lut;
+}
+
+/**
+ * Apply the sRGB OETF (linear -> sRGB encoding)
+ * and return a freshly allocated result. The input is assumed to be 8-bit
+ * per channel, with values representing linear light (0..255 mapped to
+ * linear 0..1). The returned image holds sRGB-encoded values suitable for
+ * direct display on an sRGB monitor.
+ *
+ * A new output buffer is always allocated rather than writing in place,
+ * because the caller may pass a Mat whose data is shared with read-only or
+ * aliased memory (e.g. cv_bridge::toCvShare backed by a ROS message buffer).
+ */
+inline cv::Mat linearToSrgb(const cv::Mat & image)
+{
+  static const cv::Mat lut = buildLinearToSrgbLut();
+  cv::Mat encoded;
+  cv::LUT(image, lut, encoded);
+  return encoded;
+}
+
+}  // namespace rqt_image_view
+
+#endif  // RQT_IMAGE_VIEW__LINEAR_TO_SRGB_HPP_

--- a/package.xml
+++ b/package.xml
@@ -36,8 +36,10 @@
   <exec_depend>qt_gui_cpp</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
 
+  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  <test_depend>libopencv-dev</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/src/rqt_image_view/image_view.cpp
+++ b/src/rqt_image_view/image_view.cpp
@@ -35,6 +35,7 @@
 
 #include <pluginlib/class_list_macros.hpp>
 #include <rqt_image_view/image_view.hpp>
+#include <rqt_image_view/linear_to_srgb.hpp>
 #include <sensor_msgs/image_encodings.hpp>
 
 #include <cv_bridge/cv_bridge.hpp>
@@ -179,6 +180,7 @@ void ImageView::saveSettings(
   instance_settings.setValue("toolbar_hidden", hide_toolbar_action_->isChecked());
   instance_settings.setValue("num_gridlines", ui_.num_gridlines_spin_box->value());
   instance_settings.setValue("smooth_image", ui_.smooth_image_check_box->isChecked());
+  instance_settings.setValue("linear_input", ui_.linear_input_check_box->isChecked());
   instance_settings.setValue("rotate", rotate_state_);
   instance_settings.setValue("color_scheme", ui_.color_scheme_combo_box->currentIndex());
 }
@@ -222,6 +224,9 @@ void ImageView::restoreSettings(
 
   bool smooth_image_checked = instance_settings.value("smooth_image", false).toBool();
   ui_.smooth_image_check_box->setChecked(smooth_image_checked);
+
+  bool linear_input_checked = instance_settings.value("linear_input", false).toBool();
+  ui_.linear_input_check_box->setChecked(linear_input_checked);
 
   rotate_state_ = static_cast<RotateState>(instance_settings.value("rotate", 0).toInt());
   if(rotate_state_ >= ROTATE_STATE_COUNT) {
@@ -583,6 +588,11 @@ void ImageView::overlayGrid()
 
 void ImageView::callbackImage(const sensor_msgs::msg::Image::ConstSharedPtr & msg)
 {
+  // Track whether a colormap replaced the source intensities; if it did,
+  // applying sRGB encoding on top would gamma-correct false-color codes,
+  // which is not meaningful.
+  bool colormap_applied = false;
+
   try {
     // First let cv_bridge do its magic
     cv_bridge::CvImageConstPtr cv_ptr = cv_bridge::toCvShare(msg,
@@ -631,6 +641,7 @@ void ImageView::callbackImage(const sensor_msgs::msg::Image::ConstSharedPtr & ms
           cv::Mat img_color_scheme;
           cv::applyColorMap(img_scaled_8u, img_color_scheme, color_scheme);
           cv::cvtColor(img_color_scheme, conversion_mat_, CV_BGR2RGB);
+          colormap_applied = true;
         }
       } else {
         qWarning("ImageView.callback_image() could not convert image from '%s' to 'rgb8' (%s)",
@@ -673,6 +684,10 @@ void ImageView::callbackImage(const sensor_msgs::msg::Image::ConstSharedPtr & ms
       }
     default:
       break;
+  }
+
+  if (ui_.linear_input_check_box->isChecked() && !colormap_applied) {
+    conversion_mat_ = linearToSrgb(conversion_mat_);
   }
 
   // image must be copied since it uses the conversion_mat_ for storage which is

--- a/src/rqt_image_view/image_view.ui
+++ b/src/rqt_image_view/image_view.ui
@@ -164,6 +164,16 @@
          </widget>
         </item>
         <item>
+         <widget class="QCheckBox" name="linear_input_check_box">
+          <property name="toolTip">
+           <string>Treat pixel values as linear light and apply sRGB encoding before display. Use this for sensors or sources that output linear-response images, which would otherwise appear too dark on a standard display. Has no effect when a colormap is active.</string>
+          </property>
+          <property name="text">
+           <string>Linear input</string>
+          </property>
+         </widget>
+        </item>
+        <item>
          <widget class="QPushButton" name="rotate_left_push_button">
           <property name="text">
            <string/>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,10 @@
+find_package(ament_cmake_gtest REQUIRED)
+find_package(OpenCV REQUIRED COMPONENTS core)
+
+ament_add_gtest(test_linear_to_srgb test_linear_to_srgb.cpp)
+target_include_directories(test_linear_to_srgb PRIVATE
+  "${CMAKE_CURRENT_SOURCE_DIR}/../include"
+)
+target_link_libraries(test_linear_to_srgb
+  opencv_core
+)

--- a/test/test_linear_to_srgb.cpp
+++ b/test/test_linear_to_srgb.cpp
@@ -40,9 +40,10 @@
 
 namespace
 {
-cv::Mat lut()
+const cv::Mat & lut()
 {
-  return rqt_image_view::buildLinearToSrgbLut();
+  static const cv::Mat L = rqt_image_view::buildLinearToSrgbLut();
+  return L;
 }
 
 }  // namespace

--- a/test/test_linear_to_srgb.cpp
+++ b/test/test_linear_to_srgb.cpp
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2026, Arne Baeyens
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+#include <opencv2/core/core.hpp>
+
+#include <rqt_image_view/linear_to_srgb.hpp>
+
+namespace
+{
+cv::Mat lut()
+{
+  return rqt_image_view::buildLinearToSrgbLut();
+}
+
+}  // namespace
+
+TEST(LinearToSrgb, MidGray18PercentMapsToAround118)
+{
+  // 18% linear reflectance is the classic "middle gray". After sRGB
+  // encoding it should sit roughly in the upper-middle of the 8-bit range.
+  const int linear_index = static_cast<int>(std::lround(0.18 * 255.0));
+  const int encoded = lut().at<uchar>(linear_index);
+  EXPECT_GE(encoded, 116);
+  EXPECT_LE(encoded, 120);
+}
+
+TEST(LinearToSrgb, LiftsDarkValues)
+{
+  // The whole point of the feature: linear midtones should appear brighter
+  // after encoding than they did before.
+  for (int i = 1; i < 200; ++i) {
+    EXPECT_GT(lut().at<uchar>(i), i)
+      << "Encoded value at index " << i << " should be greater than input";
+  }
+}
+
+TEST(LinearToSrgb, DoesNotMutateAliasedBuffer)
+{
+  // Regression test: cv_bridge::toCvShare hands out a cv::Mat whose data
+  // is shared with the underlying ROS message memory. If linearToSrgb were
+  // to write into that shared buffer, it would mutate foreign memory,
+  // which is undefined behavior and can crash. Verify that a Mat sharing
+  // the input buffer is left untouched.
+  cv::Mat original(1, 4, CV_8UC3);
+  original.at<cv::Vec3b>(0, 0) = cv::Vec3b(10, 20, 30);
+  original.at<cv::Vec3b>(0, 1) = cv::Vec3b(46, 46, 46);
+  original.at<cv::Vec3b>(0, 2) = cv::Vec3b(100, 150, 200);
+  original.at<cv::Vec3b>(0, 3) = cv::Vec3b(255, 255, 255);
+
+  const cv::Mat aliased = original;   // shallow copy: shares the same data buffer
+  ASSERT_EQ(aliased.data, original.data);
+
+  const cv::Mat encoded = rqt_image_view::linearToSrgb(aliased);
+
+  EXPECT_EQ(original.at<cv::Vec3b>(0, 0), cv::Vec3b(10, 20, 30));
+  EXPECT_EQ(original.at<cv::Vec3b>(0, 1), cv::Vec3b(46, 46, 46));
+  EXPECT_EQ(original.at<cv::Vec3b>(0, 2), cv::Vec3b(100, 150, 200));
+  EXPECT_EQ(original.at<cv::Vec3b>(0, 3), cv::Vec3b(255, 255, 255));
+
+  // And the returned image should hold encoded values.
+  EXPECT_GT(encoded.at<cv::Vec3b>(0, 1)[0], 46);
+}
+
+TEST(LinearToSrgb, EncodesEveryChannelOfRgbImage)
+{
+  cv::Mat img(2, 2, CV_8UC3);
+  img.at<cv::Vec3b>(0, 0) = cv::Vec3b(0, 0, 0);
+  img.at<cv::Vec3b>(0, 1) = cv::Vec3b(255, 255, 255);
+  img.at<cv::Vec3b>(1, 0) = cv::Vec3b(46, 46, 46);    // ~18% linear
+  img.at<cv::Vec3b>(1, 1) = cv::Vec3b(46, 128, 200);  // mixed channels
+
+  const cv::Mat encoded = rqt_image_view::linearToSrgb(img);
+
+  EXPECT_EQ(encoded.at<cv::Vec3b>(0, 0), cv::Vec3b(0, 0, 0));
+  EXPECT_EQ(encoded.at<cv::Vec3b>(0, 1), cv::Vec3b(255, 255, 255));
+
+  const cv::Vec3b mid = encoded.at<cv::Vec3b>(1, 0);
+  for (int c = 0; c < 3; ++c) {
+    EXPECT_GE(mid[c], 116);
+    EXPECT_LE(mid[c], 120);
+  }
+
+  // Mixed-channel pixel: each channel encoded independently and
+  // strictly brighter than the input (we're well above the toe).
+  const cv::Vec3b mixed = encoded.at<cv::Vec3b>(1, 1);
+  EXPECT_GT(mixed[0], 46);
+  EXPECT_GT(mixed[1], 128);
+  EXPECT_GT(mixed[2], 200);
+}


### PR DESCRIPTION
## Current situation
Linear response sources (e.g. cameras whose sensor output is mapped directly to 8 bit) appear too dark because pixel values are sent unchanged to the display, while basically all computer displays exhibit an (approximately) sRGB response curve. This results in those images being shown darker than they should.

## Desired situation
Linear response sources are shown with the correct brightness. ROS messages don't appear to specify the chosen encoding (also called "transfer function", "OETF" or "response curve"), so add a toggle.

## Proposed user-facing changes
* Add a "Linear input" toggle (see the screenshot below).
* When enabled, at LUT gets applied such that converts the linear image to one that follows sRGB encoding, and thus displays correctly.

Here's a screenshot, showing left the uncorrected linearly encoded image (= current situation) and on the right the corrected image:
<img width="1369" height="689" alt="Screenshot from 2026-05-16 14-44-03" src="https://github.com/user-attachments/assets/7876c50c-3757-4268-8d7d-62c1e5fc5ceb" />

## Implementation notes
- Toggle state is persisted via the existing `saveSettings`/`restoreSettings` mechanism, matching the other checkbox settings.
- Skipped when a colormap is active: gamma-correcting false-color codes is not meaningful.
- For 16-bit inputs the correction is applied post-quantization to 8-bit, so banding in shadows is possible. A follow-up could move the correction upstream to preserve precision.
- Bootstraps gtest infrastructure for the package (none existed before) and adds behavior tests covering the encoding curve, the no-mutation contract, and multi-channel application.

## Use of generative AI
Claude Opus 4.7 was used

## Questions
All feedback welcome, I consider the current implementation proposal as a PoC such that people can try it out and see what it gives for them.
