### PR TITLE
Add toggleable info bar below the image

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,9 @@ find_package(ament_cmake_python REQUIRED)
 message("Using Qt ${QT_VERSION_MAJOR}")
 
 set(rqt_image_view_SRCS
+  src/rqt_image_view/detail/framerate_estimator.cpp
+  src/rqt_image_view/detail/pixel_format.cpp
+  src/rqt_image_view/detail/pixel_mapping.cpp
   src/rqt_image_view/image_view.cpp
   src/rqt_image_view/ratio_layouted_frame.cpp
 )
@@ -101,6 +104,7 @@ install(PROGRAMS scripts/image_publisher
 install(
   DIRECTORY include/
   DESTINATION include/${PROJECT_NAME}
+  PATTERN "detail" EXCLUDE
 )
 
 install(FILES plugin.xml
@@ -123,6 +127,15 @@ ament_export_targets(${PROJECT_NAME})
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
+
+  find_package(ament_cmake_gtest REQUIRED)
+  # Note: ament_cmake_gtest links its own dependencies onto the target with
+  # the plain-form target_link_libraries; CMake then requires us to use the
+  # same form here. Visibility keyword (PRIVATE) would error out.
+  foreach(suite pixel_format pixel_mapping)
+    ament_add_gtest(test_${suite} test/test_${suite}.cpp)
+    target_link_libraries(test_${suite} ${PROJECT_NAME})
+  endforeach()
 endif()
 
 ament_package()

--- a/include/rqt_image_view/detail/framerate_estimator.hpp
+++ b/include/rqt_image_view/detail/framerate_estimator.hpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2026, Arne Baeyens
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef RQT_IMAGE_VIEW__DETAIL__FRAMERATE_ESTIMATOR_HPP_
+#define RQT_IMAGE_VIEW__DETAIL__FRAMERATE_ESTIMATOR_HPP_
+
+#include <chrono>
+#include <cstddef>
+#include <deque>
+#include <optional>
+
+namespace rqt_image_view
+{
+namespace detail
+{
+
+// Sliding-window framerate estimator over recent image arrivals.
+//
+// Uses caller-supplied steady_clock arrival times rather than header.stamp so
+// the readout reflects what the consumer is actually seeing (bag replay rate,
+// dropped frames, buffering all included).
+//
+// Not thread-safe; caller synchronizes between the producer (executor) and
+// consumer (GUI) threads.
+class FramerateEstimator
+{
+public:
+  using SteadyClock = std::chrono::steady_clock;
+  using TimePoint = SteadyClock::time_point;
+
+  static constexpr std::size_t MAX_SAMPLES = 20;
+  static constexpr double STALENESS_FLOOR_SEC = 1.0;
+  static constexpr double STALENESS_PERIOD_MULTIPLIER = 2.5;
+
+  // Record a single message arrival at wall_now.
+  void addSample(TimePoint wall_now);
+
+  // Rate in Hz over the window, or nullopt for too few samples / stalled.
+  [[nodiscard]] std::optional<double> compute(TimePoint wall_now) const noexcept;
+
+  void reset() noexcept;
+
+  [[nodiscard]] std::size_t sampleCount() const noexcept {return arrivals_.size();}
+
+private:
+  std::deque<TimePoint> arrivals_;
+};
+
+}  // namespace detail
+}  // namespace rqt_image_view
+
+#endif  // RQT_IMAGE_VIEW__DETAIL__FRAMERATE_ESTIMATOR_HPP_

--- a/include/rqt_image_view/detail/pixel_format.hpp
+++ b/include/rqt_image_view/detail/pixel_format.hpp
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026, Arne Baeyens
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef RQT_IMAGE_VIEW__DETAIL__PIXEL_FORMAT_HPP_
+#define RQT_IMAGE_VIEW__DETAIL__PIXEL_FORMAT_HPP_
+
+#include <sensor_msgs/msg/image.hpp>
+
+#include <QString>  // NOLINT
+
+namespace rqt_image_view
+{
+namespace detail
+{
+
+// Format the raw pixel value at (x, y) of `msg` for display in the info bar's
+// hover label.
+//
+// Output contract (tested):
+//   single-channel encodings (MONO8, MONO16, TYPE_8UC1, TYPE_16UC1, TYPE_32FC1)
+//                                     → plain "value:<N>"
+//   RGB8, BGR8, RGB16, BGR16          → HTML rich text "<span>R:<N></span>
+//                                                       <span>G:<N></span>
+//                                                       <span>B:<N></span>",
+//                                       R/G/B always in display order
+//   RGBA8, BGRA8, RGBA16, BGRA16      → same as above plus
+//                                       "<span>A:<N></span>"
+//   other recognised encodings        → plain "raw=[HH HH ...]" uppercase hex
+//   unrecognised / underivable stride → plain "(unsupported)"
+//   out-of-image or truncated row     → plain "(out of bounds)"
+//
+// Multi-byte channel reads assume host endianness; messages whose
+// `is_bigendian` flag disagrees with the host route to the raw-hex fallback.
+[[nodiscard]] QString formatPixelValue(const sensor_msgs::msg::Image & msg, int x, int y);
+
+}  // namespace detail
+}  // namespace rqt_image_view
+
+#endif  // RQT_IMAGE_VIEW__DETAIL__PIXEL_FORMAT_HPP_

--- a/include/rqt_image_view/detail/pixel_mapping.hpp
+++ b/include/rqt_image_view/detail/pixel_mapping.hpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026, Arne Baeyens
+ * Copyright (c) 2011, Dirk Thomas, TU Darmstadt
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the TU Darmstadt nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef RQT_IMAGE_VIEW__DETAIL__PIXEL_MAPPING_HPP_
+#define RQT_IMAGE_VIEW__DETAIL__PIXEL_MAPPING_HPP_
+
+#include <optional>
+
+#include <QPoint>  // NOLINT
+
+namespace rqt_image_view
+{
+namespace detail
+{
+
+// Recognised rotation values. Anything else passed as `rotation_degrees`
+// makes mapWidgetToImagePixel return std::nullopt.
+constexpr int ROTATION_0 = 0;
+constexpr int ROTATION_90 = 90;
+constexpr int ROTATION_180 = 180;
+constexpr int ROTATION_270 = 270;
+
+// Map a cursor position in the on-screen image widget back to the original
+// (unrotated) image pixel.
+//
+// @param widget_x,widget_y  Cursor coordinates inside the image widget.
+// @param frame_w,frame_h    Image widget dimensions in pixels.
+// @param image_w,image_h    Original image dimensions in pixels (pre-rotation).
+// @param rotation_degrees   Active display rotation. Must be one of
+//                           ROTATION_{0,90,180,270}; any other value returns
+//                           std::nullopt.
+// @returns The clamped (x, y) pixel in the original image, or std::nullopt
+//          when any input is degenerate (zero dimensions, cursor outside the
+//          widget, unrecognised rotation).
+[[nodiscard]] std::optional<QPoint> mapWidgetToImagePixel(
+  int widget_x, int widget_y,
+  int frame_w, int frame_h,
+  int image_w, int image_h,
+  int rotation_degrees);
+
+}  // namespace detail
+}  // namespace rqt_image_view
+
+#endif  // RQT_IMAGE_VIEW__DETAIL__PIXEL_MAPPING_HPP_

--- a/include/rqt_image_view/image_view.hpp
+++ b/include/rqt_image_view/image_view.hpp
@@ -35,8 +35,10 @@
 
 #include <ui_image_view.h>
 
-#include <vector>
+#include <atomic>
 #include <memory>
+#include <optional>
+#include <vector>
 
 #include <rqt_gui_cpp/plugin.hpp>
 
@@ -48,14 +50,20 @@
 
 #include <opencv2/core/core.hpp>
 
+#include <rqt_image_view/detail/framerate_estimator.hpp>
+
 #include <QAction>  // NOLINT
 #include <QImage>  // NOLINT
 #include <QList>  // NOLINT
+#include <QMutex>  // NOLINT
 #include <QObject>  // NOLINT
+#include <QPoint>  // NOLINT
 #include <QString>  // NOLINT
 #include <QSet>  // NOLINT
 #include <QSize>  // NOLINT
 #include <QWidget>  // NOLINT
+
+QT_FORWARD_DECLARE_CLASS(QTimer)
 
 namespace rqt_image_view
 {
@@ -103,12 +111,24 @@ protected slots:
 
   virtual void onMouseLeft(int x, int y);
 
+  virtual void onMouseMovedOnImage(int x, int y);
+
+  virtual void onMouseExitedImage();
+
+  // Throttle-timer callback that renders the most recent hover coordinates;
+  // see hover_throttle_timer_ for the rate-limiting design.
+  virtual void flushHoverLabel();
+
   virtual void onPubTopicChanged();
 
   virtual void onHideToolbarChanged(bool hide);
 
+  virtual void onInfoBarToggled(bool checked);
+
   virtual void onRotateLeft();
   virtual void onRotateRight();
+
+  virtual void updateInfoBarStats();
 
 protected:
   virtual void callbackImage(const sensor_msgs::msg::Image::ConstSharedPtr & msg);
@@ -140,6 +160,12 @@ private:
 
   void syncRotateLabel();
 
+  // Wire up the info-bar widgets, timers, and signal/slot connections.
+  void setupInfoBar();
+
+  // Reset the hover readout to the "no value" placeholder.
+  void clearHoverLabel();
+
   QString arg_topic_name;
 
   rclcpp::Publisher<geometry_msgs::msg::Point>::SharedPtr pub_mouse_left_;
@@ -150,7 +176,38 @@ private:
 
   int num_gridlines_;
 
-  RotateState rotate_state_;
+  // rotate_state_: written by the GUI thread (onRotateLeft/onRotateRight,
+  // restoreSettings); read by the subscriber callback (callbackImage) to
+  // decide how to rotate the just-arrived image. std::atomic makes the
+  // cross-thread read race-free under the C++17 memory model.
+  std::atomic<RotateState> rotate_state_;
+
+  // latest_msg_ + latest_rotation_degrees_: both written by the ROS subscriber
+  // callback under latest_msg_mutex_ so the hover handler reads the message
+  // together with the rotation that was actually applied to it — needed
+  // because the rotate buttons change rotate_state_ without re-rendering the
+  // currently displayed frame.
+  sensor_msgs::msg::Image::ConstSharedPtr latest_msg_;
+  int latest_rotation_degrees_;
+  mutable QMutex latest_msg_mutex_;
+
+  // framerate_estimator_: written by the subscriber callback, read by the
+  // info-bar timer; serialized with framerate_mutex_. Samples are pushed even
+  // when cv_bridge later fails so arrival rate stays measurable on broken
+  // streams — latest_msg_ in contrast only updates after a successful conversion.
+  detail::FramerateEstimator framerate_estimator_;
+  mutable QMutex framerate_mutex_;
+
+  // GUI thread only; created in initPlugin and parented to `this`.
+  QTimer * info_bar_stats_timer_;
+
+  // High-polling-rate mice (multi-kHz) can fire mouseMoveEvent faster than a
+  // RichText QLabel can re-layout, so we coalesce: onMouseMovedOnImage stores
+  // the latest position in pending_hover_ and starts the single-shot
+  // hover_throttle_timer_; flushHoverLabel() renders at most once per
+  // HOVER_THROTTLE_INTERVAL_MS. GUI thread only.
+  std::optional<QPoint> pending_hover_;
+  QTimer * hover_throttle_timer_;
 };
 
 }  // namespace rqt_image_view

--- a/include/rqt_image_view/ratio_layouted_frame.hpp
+++ b/include/rqt_image_view/ratio_layouted_frame.hpp
@@ -82,6 +82,22 @@ signals:
 
   void mouseLeft(int x, int y);
 
+  // Emitted while the cursor moves over the image frame.
+  // Coordinates are in widget-local pixels (origin at the top-left of the
+  // image frame). To map them to image pixels see
+  // rqt_image_view::detail::mapWidgetToImagePixel.
+  void mouseMovedOnImage(int x, int y);
+
+  // Emitted once when the cursor leaves the image frame.
+  void mouseExitedImage();
+
+public slots:
+  // Enable or disable hover tracking. While disabled, mouseMovedOnImage
+  // only fires while a mouse button is pressed; while enabled it fires on
+  // every cursor pixel motion. Kept off by default to keep the hot path
+  // cold when no consumer is interested.
+  void setHoverTrackingEnabled(bool enabled);
+
 protected slots:
   void onSmoothImageChanged(bool checked);
 
@@ -94,6 +110,10 @@ private:
   static int greatestCommonDivisor(int a, int b);
 
   void mousePressEvent(QMouseEvent * mouseEvent);
+
+  void mouseMoveEvent(QMouseEvent * mouseEvent);
+
+  void leaveEvent(QEvent * event);
 
   QHBoxLayout * outer_layout_;
 

--- a/package.xml
+++ b/package.xml
@@ -36,6 +36,7 @@
   <exec_depend>qt_gui_cpp</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
 
+  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 

--- a/src/rqt_image_view/detail/framerate_estimator.cpp
+++ b/src/rqt_image_view/detail/framerate_estimator.cpp
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026, Arne Baeyens
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <rqt_image_view/detail/framerate_estimator.hpp>
+
+#include <algorithm>
+
+namespace rqt_image_view
+{
+namespace detail
+{
+
+void FramerateEstimator::addSample(TimePoint wall_now)
+{
+  arrivals_.push_back(wall_now);
+  if (arrivals_.size() > MAX_SAMPLES) {
+    arrivals_.pop_front();
+  }
+}
+
+std::optional<double> FramerateEstimator::compute(TimePoint wall_now) const noexcept
+{
+  if (arrivals_.size() < 2) {
+    return std::nullopt;
+  }
+  const auto span = std::chrono::duration<double>(arrivals_.back() - arrivals_.front()).count();
+  if (span <= 0.0) {
+    return std::nullopt;
+  }
+  const double period = span / static_cast<double>(arrivals_.size() - 1);
+  const double staleness_threshold =
+    std::max(STALENESS_FLOOR_SEC, STALENESS_PERIOD_MULTIPLIER * period);
+  const double wall_since_last =
+    std::chrono::duration<double>(wall_now - arrivals_.back()).count();
+  if (wall_since_last > staleness_threshold) {
+    return std::nullopt;
+  }
+  return static_cast<double>(arrivals_.size() - 1) / span;
+}
+
+void FramerateEstimator::reset() noexcept
+{
+  arrivals_.clear();
+}
+
+}  // namespace detail
+}  // namespace rqt_image_view

--- a/src/rqt_image_view/detail/pixel_format.cpp
+++ b/src/rqt_image_view/detail/pixel_format.cpp
@@ -1,0 +1,222 @@
+/*
+ * Copyright (c) 2026, Arne Baeyens
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <rqt_image_view/detail/pixel_format.hpp>
+
+#if defined(__BYTE_ORDER__) && __BYTE_ORDER__ != __ORDER_LITTLE_ENDIAN__
+#error "rqt_image_view assumes a little-endian host"
+#endif
+
+#include <cstdint>
+#include <cstring>
+#include <string>
+
+#include <sensor_msgs/image_encodings.hpp>
+
+#include <QChar>  // NOLINT
+#include <QLatin1Char>  // NOLINT
+#include <QString>  // NOLINT
+
+namespace rqt_image_view
+{
+namespace detail
+{
+namespace
+{
+
+// Pad widths matching the maximum decimal value of each channel encoding.
+constexpr int PAD_8BIT = 3;   // 0..255
+constexpr int PAD_16BIT = 5;  // 0..65535
+
+// NBSP as fill so HTML rendering doesn't collapse the alignment padding.
+constexpr QChar NBSP(0x00A0);
+
+[[nodiscard]] std::uint16_t readU16(const std::uint8_t * p) noexcept
+{
+  std::uint16_t v;
+  std::memcpy(&v, p, sizeof(v));
+  return v;
+}
+
+[[nodiscard]] float readF32(const std::uint8_t * p) noexcept
+{
+  float v;
+  std::memcpy(&v, p, sizeof(v));
+  return v;
+}
+
+// Channel-coloured RGB/A spans. Palette follows ros2/rviz PR #1716
+// (https://github.com/ros2/rviz/pull/1716); contrast on dark themes is a
+// known limitation.
+QString formatRgbHtml(unsigned r, unsigned g, unsigned b, int pad)
+{
+  return QStringLiteral(
+    "<span style='color:#c00'>R:%1</span> "
+    "<span style='color:#0a0'>G:%2</span> "
+    "<span style='color:#06c'>B:%3</span>")
+         .arg(r, pad, 10, NBSP)
+         .arg(g, pad, 10, NBSP)
+         .arg(b, pad, 10, NBSP);
+}
+
+QString formatRgbaHtml(unsigned r, unsigned g, unsigned b, unsigned a, int pad)
+{
+  return formatRgbHtml(r, g, b, pad) +
+         QStringLiteral(" <span style='color:#aaa'>A:%1</span>").arg(a, pad, 10, NBSP);
+}
+
+// Bytes per pixel for an encoding whose layout is "<channels> × <bits>/8".
+// Returns 0 for encodings whose layout is not that simple (Bayer, planar YUV,
+// etc.) — those fall through to the raw-hex stride-guess path.
+std::size_t bytesPerPixel(const std::string & encoding)
+{
+  namespace enc = sensor_msgs::image_encodings;
+  try {
+    const int channels = enc::numChannels(encoding);
+    const int bit_depth = enc::bitDepth(encoding);
+    if (channels <= 0 || bit_depth <= 0 || (bit_depth % 8) != 0) {
+      return 0;
+    }
+    return channels * (bit_depth / 8);
+  } catch (const std::runtime_error &) {
+    return 0;
+  }
+}
+
+QString formatRawHex(const std::uint8_t * p, std::size_t n)
+{
+  QString out = QStringLiteral("raw=[");
+  for (std::size_t i = 0; i < n; ++i) {
+    if (i != 0) {
+      out += QLatin1Char(' ');
+    }
+    out += QStringLiteral("%1").arg(p[i], 2, 16, QLatin1Char('0')).toUpper();
+  }
+  out += QLatin1Char(']');
+  return out;
+}
+
+}  // namespace
+
+QString formatPixelValue(const sensor_msgs::msg::Image & msg, int x, int y)
+{
+  // The bounds arithmetic below multiplies two uint32 fields (step, height)
+  // and needs size_t to be wide enough to hold the product without wrapping.
+  // Bail out on 32-bit builds rather than allow OOB reads from a malicious bag.
+  if constexpr (sizeof(std::size_t) < 8) {
+    return QStringLiteral("(not supported on 32-bit)");
+  }
+
+  namespace enc = sensor_msgs::image_encodings;
+
+  if (x < 0 || y < 0 || msg.width == 0 || msg.height == 0) {
+    return QStringLiteral("(out of bounds)");
+  }
+  const auto ux = static_cast<std::uint32_t>(x);
+  const auto uy = static_cast<std::uint32_t>(y);
+  if (ux >= msg.width || uy >= msg.height) {
+    return QStringLiteral("(out of bounds)");
+  }
+
+  const std::size_t data_size = msg.data.size();
+  const std::size_t step = msg.step;
+  if (step == 0 || step > data_size || step * msg.height > data_size) {
+    return QStringLiteral("(out of bounds)");
+  }
+  const std::size_t row_offset = uy * step;
+
+  const std::size_t bpp = bytesPerPixel(msg.encoding);
+  if (bpp > 0) {
+    const std::size_t pixel_offset = ux * bpp;
+    if (row_offset + pixel_offset + bpp > data_size) {
+      return QStringLiteral("(out of bounds)");
+    }
+    const std::uint8_t * row = msg.data.data() + row_offset;
+    const std::uint8_t * pixel = row + pixel_offset;
+
+    // Host is little-endian (enforced at top of file); a big-endian message
+    // on multi-byte channels routes to the raw-hex fallback below.
+    const bool endian_ok = (bpp == 1) || msg.is_bigendian == 0;
+    if (endian_ok) {
+      const std::string & e = msg.encoding;
+      if (e == enc::MONO8 || e == enc::TYPE_8UC1) {
+        return QStringLiteral("value:%1").arg(pixel[0], PAD_8BIT, 10, NBSP);
+      } else if (e == enc::MONO16 || e == enc::TYPE_16UC1) {
+        return QStringLiteral("value:%1").arg(readU16(pixel), PAD_16BIT, 10, NBSP);
+      } else if (e == enc::TYPE_32FC1) {
+        return QStringLiteral("value:%1")
+               .arg(static_cast<double>(readF32(pixel)), 0, 'g', 6);
+      } else if (e == enc::RGB8) {
+        return formatRgbHtml(pixel[0], pixel[1], pixel[2], PAD_8BIT);
+      } else if (e == enc::BGR8) {
+        return formatRgbHtml(pixel[2], pixel[1], pixel[0], PAD_8BIT);
+      } else if (e == enc::RGBA8) {
+        return formatRgbaHtml(pixel[0], pixel[1], pixel[2], pixel[3], PAD_8BIT);
+      } else if (e == enc::BGRA8) {
+        return formatRgbaHtml(pixel[2], pixel[1], pixel[0], pixel[3], PAD_8BIT);
+      } else if (e == enc::RGB16) {
+        return formatRgbHtml(
+          readU16(pixel), readU16(pixel + 2), readU16(pixel + 4), PAD_16BIT);
+      } else if (e == enc::BGR16) {
+        return formatRgbHtml(
+          readU16(pixel + 4), readU16(pixel + 2), readU16(pixel), PAD_16BIT);
+      } else if (e == enc::RGBA16) {
+        return formatRgbaHtml(
+          readU16(pixel), readU16(pixel + 2), readU16(pixel + 4),
+          readU16(pixel + 6), PAD_16BIT);
+      } else if (e == enc::BGRA16) {
+        return formatRgbaHtml(
+          readU16(pixel + 4), readU16(pixel + 2), readU16(pixel),
+          readU16(pixel + 6), PAD_16BIT);
+      }
+    }
+    // Recognised-stride encoding but unhandled name (e.g. TYPE_8UC2) or
+    // endian-mismatched multi-byte data: dump raw bytes.
+    return formatRawHex(pixel, bpp);
+  }
+
+  // Encoding with no recognisable per-pixel stride: derive from msg.step.
+  // Cap the dump so a malicious publisher can't coerce a megabyte QString.
+  constexpr std::size_t MAX_RAW_BYTES_PER_PIXEL = 16;
+  const std::size_t guessed_bpp = step / msg.width;
+  if (guessed_bpp == 0 || guessed_bpp > MAX_RAW_BYTES_PER_PIXEL) {
+    return QStringLiteral("(unsupported)");
+  }
+  const std::size_t pixel_offset = ux * guessed_bpp;
+  if (row_offset + pixel_offset + guessed_bpp > data_size) {
+    return QStringLiteral("(out of bounds)");
+  }
+  return formatRawHex(msg.data.data() + row_offset + pixel_offset, guessed_bpp);
+}
+
+}  // namespace detail
+}  // namespace rqt_image_view

--- a/src/rqt_image_view/detail/pixel_mapping.cpp
+++ b/src/rqt_image_view/detail/pixel_mapping.cpp
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026, Arne Baeyens
+ * Copyright (c) 2011, Dirk Thomas, TU Darmstadt
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the TU Darmstadt nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <rqt_image_view/detail/pixel_mapping.hpp>
+
+#include <algorithm>
+
+namespace rqt_image_view
+{
+namespace detail
+{
+
+std::optional<QPoint> mapWidgetToImagePixel(
+  int widget_x, int widget_y,
+  int frame_w, int frame_h,
+  int image_w, int image_h,
+  int rotation_degrees)
+{
+  if (image_w <= 0 || image_h <= 0 || frame_w <= 0 || frame_h <= 0) {
+    return std::nullopt;
+  }
+  if (widget_x < 0 || widget_y < 0 || widget_x >= frame_w || widget_y >= frame_h) {
+    return std::nullopt;
+  }
+
+  // Displayed dimensions swap when the image is shown rotated by 90/270 degrees.
+  const bool swapped = (rotation_degrees == ROTATION_90 || rotation_degrees == ROTATION_270);
+  const int disp_w = swapped ? image_h : image_w;
+  const int disp_h = swapped ? image_w : image_h;
+
+  const double x_disp = static_cast<double>(widget_x) / frame_w * disp_w;
+  const double y_disp = static_cast<double>(widget_y) / frame_h * disp_h;
+
+  int x_orig = 0;
+  int y_orig = 0;
+  switch (rotation_degrees) {
+    case ROTATION_0:
+      x_orig = static_cast<int>(x_disp);
+      y_orig = static_cast<int>(y_disp);
+      break;
+    case ROTATION_90:
+      x_orig = static_cast<int>(y_disp);
+      y_orig = static_cast<int>((disp_w - 1) - x_disp);
+      break;
+    case ROTATION_180:
+      x_orig = static_cast<int>((disp_w - 1) - x_disp);
+      y_orig = static_cast<int>((disp_h - 1) - y_disp);
+      break;
+    case ROTATION_270:
+      x_orig = static_cast<int>((disp_h - 1) - y_disp);
+      y_orig = static_cast<int>(x_disp);
+      break;
+    default:
+      return std::nullopt;
+  }
+  x_orig = std::clamp(x_orig, 0, image_w - 1);
+  y_orig = std::clamp(y_orig, 0, image_h - 1);
+  return QPoint(x_orig, y_orig);
+}
+
+}  // namespace detail
+}  // namespace rqt_image_view

--- a/src/rqt_image_view/image_view.cpp
+++ b/src/rqt_image_view/image_view.cpp
@@ -31,19 +31,27 @@
  */
 
 
+#include <algorithm>
+#include <chrono>
+#include <optional>
 #include <vector>
 
 #include <pluginlib/class_list_macros.hpp>
+#include <rqt_image_view/detail/pixel_format.hpp>
+#include <rqt_image_view/detail/pixel_mapping.hpp>
 #include <rqt_image_view/image_view.hpp>
-#include <sensor_msgs/image_encodings.hpp>
 
 #include <cv_bridge/cv_bridge.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
 
 #include <QFileDialog>  // NOLINT
+#include <QFont>  // NOLINT
+#include <QFontDatabase>  // NOLINT
 #include <QMessageBox>  // NOLINT
 #include <QPainter>  // NOLINT
+#include <QPoint>  // NOLINT
 #include <QRegularExpressionValidator>  // NOLINT
+#include <QTimer>  // NOLINT
 
 namespace rqt_image_view
 {
@@ -65,11 +73,29 @@ static const std::map<std::string, int> COLOR_SCHEME_MAP
   {"Winter", cv::COLORMAP_WINTER}
 };  // following OpenCV options https://docs.opencv.org/4.x/d3/d50/group__imgproc__colormap.html
 
+namespace
+{
+constexpr int INFO_BAR_UPDATE_INTERVAL_MS = 500;
+// Coalescing interval for the hover label; see hover_throttle_timer_.
+constexpr int HOVER_THROTTLE_INTERVAL_MS = 30;
+
+// Right-pad to this width so the framerate field doesn't shift neighbours.
+constexpr int FRAMERATE_FIELD_WIDTH = 4;
+constexpr const char * FRAMERATE_SIZING_SAMPLE = "99.9 Hz";
+constexpr double SUB_HERTZ_FLOOR = 0.05;
+
+// NBSP as fill so HTML rendering doesn't collapse the alignment padding.
+constexpr QChar NBSP(0x00A0);
+}  // namespace
+
 ImageView::ImageView()
 : rqt_gui_cpp::Plugin()
   , widget_(0)
   , num_gridlines_(0)
   , rotate_state_(ROTATE_0)
+  , latest_rotation_degrees_(0)
+  , info_bar_stats_timer_(nullptr)
+  , hover_throttle_timer_(nullptr)
 {
   setObjectName("ImageView");
 }
@@ -154,6 +180,44 @@ void ImageView::initPlugin(qt_gui_cpp::PluginContext & context)
   hide_toolbar_action_->setCheckable(true);
   ui_.image_frame->addAction(hide_toolbar_action_);
   connect(hide_toolbar_action_, SIGNAL(toggled(bool)), this, SLOT(onHideToolbarChanged(bool)));
+
+  setupInfoBar();
+}
+
+void ImageView::setupInfoBar()
+{
+  ui_.info_bar_toggle_button->setIcon(QIcon::fromTheme("dialog-information"));
+  ui_.resolution_label->setTextFormat(Qt::PlainText);
+  ui_.encoding_label->setTextFormat(Qt::PlainText);
+  ui_.framerate_label->setTextFormat(Qt::PlainText);
+  ui_.hover_label->setTextFormat(Qt::RichText);
+  // Use the platform's fixed-pitch font for the whole info bar so that the
+  // padded numbers (framerate, hover coords, channel values) stay column-
+  // aligned and do not shift neighbours as values change magnitude.
+  ui_.info_bar_widget->setFont(QFontDatabase::systemFont(QFontDatabase::FixedFont));
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+  ui_.framerate_label->setMinimumWidth(
+    ui_.framerate_label->fontMetrics().horizontalAdvance(FRAMERATE_SIZING_SAMPLE)
+  );
+#else
+  ui_.framerate_label->setMinimumWidth(
+    ui_.framerate_label->fontMetrics().width(FRAMERATE_SIZING_SAMPLE)
+  );
+#endif
+  connect(ui_.info_bar_toggle_button, SIGNAL(toggled(bool)), this,
+      SLOT(onInfoBarToggled(bool)));
+  connect(ui_.image_frame, SIGNAL(mouseMovedOnImage(int,int)), this,  // NOLINT
+      SLOT(onMouseMovedOnImage(int,int)));  // NOLINT
+  connect(ui_.image_frame, SIGNAL(mouseExitedImage()), this, SLOT(onMouseExitedImage()));
+
+  info_bar_stats_timer_ = new QTimer(this);
+  info_bar_stats_timer_->setInterval(INFO_BAR_UPDATE_INTERVAL_MS);
+  connect(info_bar_stats_timer_, SIGNAL(timeout()), this, SLOT(updateInfoBarStats()));
+
+  hover_throttle_timer_ = new QTimer(this);
+  hover_throttle_timer_->setInterval(HOVER_THROTTLE_INTERVAL_MS);
+  hover_throttle_timer_->setSingleShot(true);
+  connect(hover_throttle_timer_, SIGNAL(timeout()), this, SLOT(flushHoverLabel()));
 }
 
 void ImageView::shutdownPlugin()
@@ -179,8 +243,9 @@ void ImageView::saveSettings(
   instance_settings.setValue("toolbar_hidden", hide_toolbar_action_->isChecked());
   instance_settings.setValue("num_gridlines", ui_.num_gridlines_spin_box->value());
   instance_settings.setValue("smooth_image", ui_.smooth_image_check_box->isChecked());
-  instance_settings.setValue("rotate", rotate_state_);
+  instance_settings.setValue("rotate", rotate_state_.load(std::memory_order_relaxed));
   instance_settings.setValue("color_scheme", ui_.color_scheme_combo_box->currentIndex());
+  instance_settings.setValue("show_info_bar", ui_.info_bar_toggle_button->isChecked());
 }
 
 void ImageView::restoreSettings(
@@ -223,15 +288,23 @@ void ImageView::restoreSettings(
   bool smooth_image_checked = instance_settings.value("smooth_image", false).toBool();
   ui_.smooth_image_check_box->setChecked(smooth_image_checked);
 
-  rotate_state_ = static_cast<RotateState>(instance_settings.value("rotate", 0).toInt());
-  if(rotate_state_ >= ROTATE_STATE_COUNT) {
-    rotate_state_ = ROTATE_0;
+  {
+    auto restored = static_cast<RotateState>(instance_settings.value("rotate", 0).toInt());
+    if (restored >= ROTATE_STATE_COUNT) {
+      restored = ROTATE_0;
+    }
+    rotate_state_.store(restored, std::memory_order_relaxed);
   }
   syncRotateLabel();
 
   // set default color scheme to Gray
   ui_.color_scheme_combo_box->setCurrentIndex(ui_.color_scheme_combo_box->findText("Gray"));
   ui_.color_scheme_combo_box->setCurrentText("Gray");
+
+  const bool show_info_bar = instance_settings.value("show_info_bar", false).toBool();
+  ui_.info_bar_toggle_button->setChecked(show_info_bar);
+  // setChecked() is silent when state matches the .ui default; sync explicitly.
+  onInfoBarToggled(show_info_bar);
 }
 
 void ImageView::updateTopicList()
@@ -345,10 +418,33 @@ void ImageView::onTopicChanged(int index)
 {
   conversion_mat_.release();
 
+  // shutdown() is not a synchronous drain; an in-flight callback may briefly
+  // re-seed the state we reset below, but the next assignments overwrite it.
   subscriber_.shutdown();
+
+  {
+    QMutexLocker lock(&latest_msg_mutex_);
+    latest_msg_.reset();
+    latest_rotation_degrees_ = 0;
+  }
+  {
+    QMutexLocker lock(&framerate_mutex_);
+    framerate_estimator_.reset();
+  }
+  pending_hover_.reset();
+  if (hover_throttle_timer_ != nullptr) {
+    hover_throttle_timer_->stop();
+  }
 
   // reset image on topic change
   ui_.image_frame->setImage(QImage());
+
+  // Refresh the info-bar labels immediately rather than waiting for the next
+  // 500 ms tick to clear the stale resolution/encoding/framerate.
+  if (ui_.info_bar_toggle_button->isChecked()) {
+    updateInfoBarStats();
+    clearHoverLabel();
+  }
 
   QStringList parts = ui_.topics_combo_box->itemData(index).toString().split(" ");
   QString topic = parts.first();
@@ -371,7 +467,14 @@ void ImageView::onTopicChanged(int index)
         subscription_options);
       qDebug("ImageView::onTopicChanged() to topic '%s' with transport '%s'",
           topic.toStdString().c_str(), subscriber_.getTransport().c_str());
-    } catch (image_transport::TransportLoadException & e) {
+    } catch (const std::exception & e) {
+      // Broad catch: an uncaught exception out of a Qt slot is UB in Qt 6.
+      RCLCPP_ERROR(
+        node_->get_logger(),
+        "rqt_image_view: failed to subscribe to '%s' with transport '%s': %s",
+        topic.toStdString().c_str(),
+        transport.toStdString().c_str(),
+        e.what());
       QMessageBox::warning(widget_, tr("Loading image transport plugin failed"), e.what());
     }
   }
@@ -454,7 +557,7 @@ void ImageView::onMouseLeft(int x, int y)
 
     geometry_msgs::msg::Point clickLocation = clickCanvasLocation;
 
-    switch(rotate_state_) {
+    switch (rotate_state_.load(std::memory_order_relaxed)) {
       case ROTATE_90:
         clickLocation.x = clickCanvasLocation.y;
         clickLocation.y = ui_.image_frame->getImage().width() - clickCanvasLocation.x;
@@ -475,6 +578,74 @@ void ImageView::onMouseLeft(int x, int y)
   }
 }
 
+void ImageView::onMouseMovedOnImage(int widget_x, int widget_y)
+{
+  if (!ui_.info_bar_toggle_button->isChecked()) {
+    return;
+  }
+  pending_hover_ = QPoint(widget_x, widget_y);
+  if (!hover_throttle_timer_->isActive()) {
+    hover_throttle_timer_->start();
+  }
+}
+
+void ImageView::onMouseExitedImage()
+{
+  // Drop any in-flight throttle so we don't immediately overwrite the
+  // exit-state placeholder with a stale hover update.
+  hover_throttle_timer_->stop();
+  pending_hover_.reset();
+  if (ui_.info_bar_toggle_button->isChecked()) {
+    clearHoverLabel();
+  }
+}
+
+void ImageView::flushHoverLabel()
+{
+  if (!pending_hover_.has_value()) {
+    return;
+  }
+  const QPoint widget_pos = *pending_hover_;
+  pending_hover_.reset();
+
+  sensor_msgs::msg::Image::ConstSharedPtr msg;
+  int rotation_degrees = 0;
+  {
+    QMutexLocker lock(&latest_msg_mutex_);
+    msg = latest_msg_;
+    rotation_degrees = latest_rotation_degrees_;
+  }
+  if (!msg) {
+    clearHoverLabel();
+    return;
+  }
+  const auto pixel = detail::mapWidgetToImagePixel(
+    widget_pos.x(), widget_pos.y(),
+    ui_.image_frame->width(), ui_.image_frame->height(),
+    static_cast<int>(msg->width), static_cast<int>(msg->height),
+    rotation_degrees);
+  if (!pixel) {
+    clearHoverLabel();
+    return;
+  }
+  const int x = pixel->x();
+  const int y = pixel->y();
+  const int x_pad =
+    QString::number(std::max(0, static_cast<int>(msg->width) - 1)).size();
+  const int y_pad =
+    QString::number(std::max(0, static_cast<int>(msg->height) - 1)).size();
+  ui_.hover_label->setText(
+    tr("Pixel(%1, %2) %3")
+    .arg(x, x_pad, 10, NBSP)
+    .arg(y, y_pad, 10, NBSP)
+    .arg(detail::formatPixelValue(*msg, x, y)));
+}
+
+void ImageView::clearHoverLabel()
+{
+  ui_.hover_label->setText(tr("Pixel —"));
+}
+
 void ImageView::onPubTopicChanged()
 {
   pub_topic_custom_ = !(ui_.publish_click_location_topic_line_edit->text().isEmpty());
@@ -486,26 +657,80 @@ void ImageView::onHideToolbarChanged(bool hide)
   ui_.toolbar_widget->setVisible(!hide);
 }
 
+void ImageView::onInfoBarToggled(bool checked)
+{
+  ui_.info_bar_widget->setVisible(checked);
+  // Only track hover while the bar is visible — otherwise every mouse pixel
+  // would still wake up onMouseMovedOnImage for nothing.
+  ui_.image_frame->setHoverTrackingEnabled(checked);
+  if (checked) {
+    updateInfoBarStats();
+    info_bar_stats_timer_->start();
+  } else {
+    info_bar_stats_timer_->stop();
+    hover_throttle_timer_->stop();
+    pending_hover_.reset();
+  }
+}
+
 void ImageView::onRotateLeft()
 {
-  int m = rotate_state_ - 1;
-  if(m < 0) {
-    m = ROTATE_STATE_COUNT - 1;
+  const int current = rotate_state_.load(std::memory_order_relaxed);
+  int next = current - 1;
+  if (next < 0) {
+    next = ROTATE_STATE_COUNT - 1;
   }
-
-  rotate_state_ = static_cast<RotateState>(m);
+  rotate_state_.store(static_cast<RotateState>(next), std::memory_order_relaxed);
   syncRotateLabel();
 }
 
 void ImageView::onRotateRight()
 {
-  rotate_state_ = static_cast<RotateState>((rotate_state_ + 1) % ROTATE_STATE_COUNT);
+  const int current = rotate_state_.load(std::memory_order_relaxed);
+  rotate_state_.store(
+    static_cast<RotateState>((current + 1) % ROTATE_STATE_COUNT),
+    std::memory_order_relaxed);
   syncRotateLabel();
+}
+
+void ImageView::updateInfoBarStats()
+{
+  sensor_msgs::msg::Image::ConstSharedPtr msg;
+  {
+    QMutexLocker lock(&latest_msg_mutex_);
+    msg = latest_msg_;
+  }
+  if (msg) {
+    ui_.resolution_label->setText(tr("%1×%2").arg(msg->width).arg(msg->height));
+    constexpr int MAX_ENCODING_CHARS = 32;
+    QString encoding = QString::fromStdString(msg->encoding);
+    if (encoding.size() > MAX_ENCODING_CHARS) {
+      encoding = encoding.left(MAX_ENCODING_CHARS - 1) + QChar(0x2026);  // …
+    }
+    ui_.encoding_label->setText(encoding);
+  } else {
+    ui_.resolution_label->setText(tr("—"));
+    ui_.encoding_label->setText(tr("—"));
+  }
+
+  std::optional<double> fps;
+  {
+    QMutexLocker lock(&framerate_mutex_);
+    fps = framerate_estimator_.compute(std::chrono::steady_clock::now());
+  }
+  if (!fps.has_value()) {
+    ui_.framerate_label->setText(
+      tr("%1 Hz").arg(QStringLiteral("—"), FRAMERATE_FIELD_WIDTH, NBSP));
+  } else if (*fps < SUB_HERTZ_FLOOR) {
+    ui_.framerate_label->setText(tr("<.05 Hz"));
+  } else {
+    ui_.framerate_label->setText(tr("%1 Hz").arg(*fps, FRAMERATE_FIELD_WIDTH, 'f', 1));
+  }
 }
 
 void ImageView::syncRotateLabel()
 {
-  switch(rotate_state_) {
+  switch (rotate_state_.load(std::memory_order_relaxed)) {
     default:
     case ROTATE_0:   ui_.rotate_label->setText("0°"); break;
     case ROTATE_90:  ui_.rotate_label->setText("90°"); break;
@@ -583,6 +808,21 @@ void ImageView::overlayGrid()
 
 void ImageView::callbackImage(const sensor_msgs::msg::Image::ConstSharedPtr & msg)
 {
+  // Framerate tracks every arrival regardless of whether the message is
+  // displayable (a publisher whose stream is "broken" still has a measurable
+  // rate, which is useful diagnostic information).
+  const auto now_wall = std::chrono::steady_clock::now();
+  {
+    QMutexLocker lock(&framerate_mutex_);
+    framerate_estimator_.addSample(now_wall);
+  }
+
+  // Snapshot the rotation once so it stays consistent across this callback
+  // (rotate switch below) and is also what we publish alongside latest_msg_
+  // for the hover handler to use.
+  const RotateState applied_rotation = rotate_state_.load(std::memory_order_relaxed);
+  const int applied_rotation_degrees = applied_rotation * 90;
+
   try {
     // First let cv_bridge do its magic
     cv_bridge::CvImageConstPtr cv_ptr = cv_bridge::toCvShare(msg,
@@ -648,8 +888,8 @@ void ImageView::callbackImage(const sensor_msgs::msg::Image::ConstSharedPtr & ms
     }
   }
 
-  // Handle rotation
-  switch(rotate_state_) {
+  // Handle rotation (apply the snapshot taken at the top of this callback).
+  switch (applied_rotation) {
     case ROTATE_90:
       {
         cv::Mat tmp;
@@ -673,6 +913,14 @@ void ImageView::callbackImage(const sensor_msgs::msg::Image::ConstSharedPtr & ms
       }
     default:
       break;
+  }
+
+  // Publish to the hover-readout path only after a successful conversion;
+  // failed frames early-return above so latest_msg_ keeps its previous value.
+  {
+    QMutexLocker lock(&latest_msg_mutex_);
+    latest_msg_ = msg;
+    latest_rotation_degrees_ = applied_rotation_degrees;
   }
 
   // image must be copied since it uses the conversion_mat_ for storage which is

--- a/src/rqt_image_view/image_view.ui
+++ b/src/rqt_image_view/image_view.ui
@@ -16,7 +16,7 @@
   <property name="windowTitle">
    <string>Image View</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,1">
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,1,0">
    <property name="margin">
     <number>0</number>
    </property>
@@ -119,6 +119,23 @@
             <width>16</width>
             <height>16</height>
            </size>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="info_bar_toggle_button">
+          <property name="toolTip">
+           <string>Toggle image info bar</string>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+          <property name="icon">
+           <iconset theme="dialog-information">
+            <normaloff>.</normaloff>.</iconset>
+          </property>
+          <property name="checkable">
+           <bool>true</bool>
           </property>
          </widget>
         </item>
@@ -284,6 +301,80 @@
       </widget>
      </item>
     </layout>
+   </item>
+   <item>
+    <widget class="QWidget" name="info_bar_widget" native="true">
+     <property name="visible">
+      <bool>false</bool>
+     </property>
+     <layout class="QHBoxLayout" name="info_bar_layout">
+      <property name="leftMargin">
+       <number>4</number>
+      </property>
+      <property name="topMargin">
+       <number>2</number>
+      </property>
+      <property name="rightMargin">
+       <number>4</number>
+      </property>
+      <property name="bottomMargin">
+       <number>2</number>
+      </property>
+      <item>
+       <widget class="QLabel" name="resolution_label">
+        <property name="toolTip">
+         <string>Image resolution (width × height)</string>
+        </property>
+        <property name="text">
+         <string>—</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="encoding_label">
+        <property name="toolTip">
+         <string>Image encoding (sensor_msgs/Image.encoding)</string>
+        </property>
+        <property name="text">
+         <string>—</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="framerate_label">
+        <property name="toolTip">
+         <string>Measured framerate</string>
+        </property>
+        <property name="text">
+         <string>—</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="info_bar_spacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>10</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QLabel" name="hover_label">
+        <property name="toolTip">
+         <string>Pixel under cursor (image coordinates and raw value)</string>
+        </property>
+        <property name="text">
+         <string>—</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/src/rqt_image_view/ratio_layouted_frame.cpp
+++ b/src/rqt_image_view/ratio_layouted_frame.cpp
@@ -47,6 +47,8 @@ RatioLayoutedFrame::RatioLayoutedFrame(QWidget * parent, Qt::WindowFlags flags)
 {
   (void)parent;
   (void)flags;
+  // Hover tracking is off by default; ImageView turns it on while the info
+  // bar is visible (see setHoverTrackingEnabled).
   connect(this, SIGNAL(delayed_update()), this, SLOT(update()), Qt::QueuedConnection);
 }
 
@@ -203,6 +205,28 @@ void RatioLayoutedFrame::mousePressEvent(QMouseEvent * mouseEvent)
     emit mouseLeft(static_cast<int>(click_pos.x()), static_cast<int>(click_pos.y()));
   }
   QFrame::mousePressEvent(mouseEvent);
+}
+
+void RatioLayoutedFrame::mouseMoveEvent(QMouseEvent * mouseEvent)
+{
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+  const QPointF pos = mouseEvent->position();
+#else
+  const QPointF pos = mouseEvent->localPos();
+#endif
+  emit mouseMovedOnImage(static_cast<int>(pos.x()), static_cast<int>(pos.y()));
+  QFrame::mouseMoveEvent(mouseEvent);
+}
+
+void RatioLayoutedFrame::leaveEvent(QEvent * event)
+{
+  emit mouseExitedImage();
+  QFrame::leaveEvent(event);
+}
+
+void RatioLayoutedFrame::setHoverTrackingEnabled(bool enabled)
+{
+  setMouseTracking(enabled);
 }
 
 void RatioLayoutedFrame::onSmoothImageChanged(bool checked)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,9 +9,6 @@ target_link_libraries(test_linear_to_srgb
   opencv_core
 )
 
-# Note: ament_cmake_gtest links its own dependencies onto the target with
-# the plain-form target_link_libraries; CMake then requires us to use the
-# same form here. Visibility keyword (PRIVATE) would error out.
 foreach(suite pixel_format pixel_mapping)
   ament_add_gtest(test_${suite} test_${suite}.cpp)
   target_link_libraries(test_${suite} ${PROJECT_NAME})

--- a/test/test_pixel_format.cpp
+++ b/test/test_pixel_format.cpp
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2026, Arne Baeyens
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <cstring>
+#include <string>
+
+#include <sensor_msgs/image_encodings.hpp>
+#include <sensor_msgs/msg/image.hpp>
+
+#include <rqt_image_view/detail/pixel_format.hpp>
+
+namespace
+{
+
+namespace enc = sensor_msgs::image_encodings;
+
+sensor_msgs::msg::Image makeImage(
+  std::uint32_t w, std::uint32_t h, const std::string & encoding, std::uint32_t step)
+{
+  sensor_msgs::msg::Image msg;
+  msg.width = w;
+  msg.height = h;
+  msg.encoding = encoding;
+  msg.step = step;
+  msg.is_bigendian = 0;
+  msg.data.assign(static_cast<std::size_t>(step) * h, 0);
+  return msg;
+}
+
+}  // namespace
+
+TEST(FormatPixelValue, OutOfBoundsCoordinatesReportSentinel)
+{
+  auto msg = makeImage(4, 4, enc::MONO8, 4);
+  EXPECT_EQ(rqt_image_view::detail::formatPixelValue(msg, -1, 0), QString("(out of bounds)"));
+  EXPECT_EQ(rqt_image_view::detail::formatPixelValue(msg, 0, -1), QString("(out of bounds)"));
+  EXPECT_EQ(rqt_image_view::detail::formatPixelValue(msg, 4, 0), QString("(out of bounds)"));
+  EXPECT_EQ(rqt_image_view::detail::formatPixelValue(msg, 0, 4), QString("(out of bounds)"));
+}
+
+TEST(FormatPixelValue, TruncatedDataReportsSentinelInsteadOfReadingPastEnd)
+{
+  // Step is correct, but the data vector is shorter than declared height.
+  auto msg = makeImage(4, 4, enc::MONO8, 4);
+  msg.data.resize(2);
+  EXPECT_EQ(rqt_image_view::detail::formatPixelValue(msg, 0, 1), QString("(out of bounds)"));
+}
+
+TEST(FormatPixelValue, MalformedStepNeverReadsBeyondRow)
+{
+  // RGB8 requires 3 bytes/pixel, so width=4 implies step ≥ 12. A publisher
+  // that reports step=6 (truncating the row to 2 valid pixels) must not lead
+  // to an out-of-row read at x=3.
+  auto msg = makeImage(4, 1, enc::RGB8, 6);
+  msg.data.assign(6, 0xAB);
+  // Within the valid prefix this is decoded normally.
+  EXPECT_NE(rqt_image_view::detail::formatPixelValue(msg, 0, 0), QString("(out of bounds)"));
+  // Past the prefix we must get a bounds sentinel, not heap-OOB bytes.
+  EXPECT_EQ(rqt_image_view::detail::formatPixelValue(msg, 3, 0), QString("(out of bounds)"));
+}
+
+TEST(FormatPixelValue, Mono8RendersValueLabel)
+{
+  auto msg = makeImage(2, 1, enc::MONO8, 2);
+  msg.data = {42, 200};
+  const auto s0 = rqt_image_view::detail::formatPixelValue(msg, 0, 0);
+  const auto s1 = rqt_image_view::detail::formatPixelValue(msg, 1, 0);
+  EXPECT_TRUE(s0.contains("value:")) << s0.toStdString();
+  EXPECT_TRUE(s0.contains("42")) << s0.toStdString();
+  EXPECT_TRUE(s1.contains("200")) << s1.toStdString();
+}
+
+TEST(FormatPixelValue, Mono16RendersDecimalValue)
+{
+  auto msg = makeImage(1, 1, enc::MONO16, 2);
+  msg.data = {0x34, 0x12};  // 0x1234 little-endian
+  EXPECT_TRUE(rqt_image_view::detail::formatPixelValue(msg, 0, 0).contains("4660"));
+}
+
+TEST(FormatPixelValue, Float32RendersValueLabel)
+{
+  auto msg = makeImage(1, 1, enc::TYPE_32FC1, 4);
+  const float v = 3.14159f;
+  std::memcpy(msg.data.data(), &v, sizeof(v));
+  const auto s = rqt_image_view::detail::formatPixelValue(msg, 0, 0);
+  EXPECT_TRUE(s.contains("3.14")) << s.toStdString();
+}
+
+TEST(FormatPixelValue, Rgb8ShowsAllThreeChannels)
+{
+  auto msg = makeImage(1, 1, enc::RGB8, 3);
+  msg.data = {10, 20, 30};
+  const auto s = rqt_image_view::detail::formatPixelValue(msg, 0, 0);
+  EXPECT_TRUE(s.contains("R:")) << s.toStdString();
+  EXPECT_TRUE(s.contains("G:")) << s.toStdString();
+  EXPECT_TRUE(s.contains("B:")) << s.toStdString();
+  EXPECT_TRUE(s.contains("10"));
+  EXPECT_TRUE(s.contains("20"));
+  EXPECT_TRUE(s.contains("30"));
+}
+
+TEST(FormatPixelValue, Bgr8DisplaysRGBOrderRegardlessOfMemoryLayout)
+{
+  // Memory layout for BGR8 is B@0, G@1, R@2; the display order is still RGB.
+  // So the R: label must show the value at offset 2, not offset 0.
+  auto msg = makeImage(1, 1, enc::BGR8, 3);
+  msg.data = {/*B=*/10, /*G=*/20, /*R=*/30};
+  const auto s = rqt_image_view::detail::formatPixelValue(msg, 0, 0);
+  const auto r_pos = s.indexOf("R:");
+  const auto g_pos = s.indexOf("G:");
+  const auto b_pos = s.indexOf("B:");
+  ASSERT_NE(r_pos, -1);
+  ASSERT_NE(g_pos, -1);
+  ASSERT_NE(b_pos, -1);
+  EXPECT_LT(r_pos, g_pos);
+  EXPECT_LT(g_pos, b_pos);
+  EXPECT_TRUE(s.mid(r_pos, g_pos - r_pos).contains("30"));
+  EXPECT_TRUE(s.mid(b_pos).contains("10"));
+}
+
+TEST(FormatPixelValue, Rgba8IncludesAlphaChannel)
+{
+  auto msg = makeImage(1, 1, enc::RGBA8, 4);
+  msg.data = {1, 2, 3, 255};
+  const auto s = rqt_image_view::detail::formatPixelValue(msg, 0, 0);
+  EXPECT_TRUE(s.contains("A:")) << s.toStdString();
+  EXPECT_TRUE(s.contains("255"));
+}
+
+TEST(FormatPixelValue, Bgra16DisplaysFourChannels)
+{
+  auto msg = makeImage(1, 1, enc::BGRA16, 8);
+  // 10, 20, 30, 40 little-endian
+  msg.data = {0x0A, 0x00, 0x14, 0x00, 0x1E, 0x00, 0x28, 0x00};
+  const auto s = rqt_image_view::detail::formatPixelValue(msg, 0, 0);
+  EXPECT_TRUE(s.contains("R:")) << s.toStdString();
+  EXPECT_TRUE(s.contains("A:")) << s.toStdString();
+  // BGRA in memory ⇒ B=10, G=20, R=30, A=40
+  EXPECT_TRUE(s.contains("10"));
+  EXPECT_TRUE(s.contains("20"));
+  EXPECT_TRUE(s.contains("30"));
+  EXPECT_TRUE(s.contains("40"));
+}
+
+TEST(FormatPixelValue, UnknownEncodingWithDerivableStrideDumpsRawHex)
+{
+  // "fancy_format" is not recognised by sensor_msgs::image_encodings, but
+  // msg.step (3) lets us derive a 3-byte stride and dump those bytes.
+  auto msg = makeImage(1, 1, "fancy_format", 3);
+  msg.data = {0xDE, 0xAD, 0xBE};
+  const auto s = rqt_image_view::detail::formatPixelValue(msg, 0, 0);
+  EXPECT_TRUE(s.startsWith("raw=")) << s.toStdString();
+  EXPECT_TRUE(s.toUpper().contains("DE"));
+  EXPECT_TRUE(s.toUpper().contains("AD"));
+  EXPECT_TRUE(s.toUpper().contains("BE"));
+}
+
+TEST(FormatPixelValue, ZeroStepReturnsOutOfBounds)
+{
+  // A step of zero cannot satisfy the row-bound invariant; the function must
+  // refuse to read rather than silently use a fallback that could overrun.
+  auto msg = makeImage(4, 4, "fancy_format", 0);
+  msg.data.assign(16, 0);
+  EXPECT_EQ(rqt_image_view::detail::formatPixelValue(msg, 0, 0), QString("(out of bounds)"));
+}

--- a/test/test_pixel_mapping.cpp
+++ b/test/test_pixel_mapping.cpp
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2026, Arne Baeyens
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <gtest/gtest.h>
+
+#include <rqt_image_view/detail/pixel_mapping.hpp>
+
+using rqt_image_view::detail::mapWidgetToImagePixel;
+
+TEST(MapWidgetToImagePixel, ZeroDimensionReturnsNullopt)
+{
+  EXPECT_FALSE(mapWidgetToImagePixel(0, 0, 100, 100, 0, 100, 0).has_value());
+  EXPECT_FALSE(mapWidgetToImagePixel(0, 0, 100, 100, 100, 0, 0).has_value());
+  EXPECT_FALSE(mapWidgetToImagePixel(0, 0, 0, 100, 100, 100, 0).has_value());
+  EXPECT_FALSE(mapWidgetToImagePixel(0, 0, 100, 0, 100, 100, 0).has_value());
+}
+
+TEST(MapWidgetToImagePixel, CursorOutsideFrameReturnsNullopt)
+{
+  EXPECT_FALSE(mapWidgetToImagePixel(-1, 0, 100, 100, 100, 100, 0).has_value());
+  EXPECT_FALSE(mapWidgetToImagePixel(100, 0, 100, 100, 100, 100, 0).has_value());
+  EXPECT_FALSE(mapWidgetToImagePixel(0, -1, 100, 100, 100, 100, 0).has_value());
+  EXPECT_FALSE(mapWidgetToImagePixel(0, 100, 100, 100, 100, 100, 0).has_value());
+}
+
+TEST(MapWidgetToImagePixel, InvalidRotationReturnsNullopt)
+{
+  EXPECT_FALSE(mapWidgetToImagePixel(50, 50, 100, 100, 100, 100, 45).has_value());
+  EXPECT_FALSE(mapWidgetToImagePixel(50, 50, 100, 100, 100, 100, -90).has_value());
+  EXPECT_FALSE(mapWidgetToImagePixel(50, 50, 100, 100, 100, 100, 360).has_value());
+}
+
+TEST(MapWidgetToImagePixel, Rotation0WithMatchingFrameMapsIdentity)
+{
+  const auto p = mapWidgetToImagePixel(13, 27, 100, 100, 100, 100, 0);
+  ASSERT_TRUE(p.has_value());
+  EXPECT_EQ(p->x(), 13);
+  EXPECT_EQ(p->y(), 27);
+}
+
+TEST(MapWidgetToImagePixel, Rotation180InvertsBothAxes)
+{
+  const auto p = mapWidgetToImagePixel(10, 20, 100, 100, 100, 100, 180);
+  ASSERT_TRUE(p.has_value());
+  EXPECT_EQ(p->x(), 89);
+  EXPECT_EQ(p->y(), 79);
+}
+
+TEST(MapWidgetToImagePixel, Rotation90SwapsAndFlipsX)
+{
+  // Image is 100×80 ⇒ displayed frame 80×100 after rotating 90° CW.
+  // Widget (40, 50) inside the 80×100 frame should map to original (50, 39).
+  const auto p = mapWidgetToImagePixel(40, 50, 80, 100, 100, 80, 90);
+  ASSERT_TRUE(p.has_value());
+  EXPECT_EQ(p->x(), 50);
+  EXPECT_EQ(p->y(), 39);
+}
+
+TEST(MapWidgetToImagePixel, Rotation270SwapsAndFlipsY)
+{
+  // Same image as 90° test, rotated 90° CCW instead. Widget (40, 50) in a
+  // 80×100 frame ⇒ original (49, 40).
+  const auto p = mapWidgetToImagePixel(40, 50, 80, 100, 100, 80, 270);
+  ASSERT_TRUE(p.has_value());
+  EXPECT_EQ(p->x(), 49);
+  EXPECT_EQ(p->y(), 40);
+}
+
+TEST(MapWidgetToImagePixel, ResultIsClampedToImageBounds)
+{
+  // Every rotation, every corner of the frame ⇒ pixel inside [0, w-1] × [0, h-1].
+  for (int rot : {0, 90, 180, 270}) {
+    for (int wx : {0, 99}) {
+      for (int wy : {0, 99}) {
+        const auto p = mapWidgetToImagePixel(wx, wy, 100, 100, 100, 100, rot);
+        ASSERT_TRUE(p.has_value()) << "rot=" << rot << " (" << wx << ", " << wy << ")";
+        EXPECT_GE(p->x(), 0);
+        EXPECT_LE(p->x(), 99);
+        EXPECT_GE(p->y(), 0);
+        EXPECT_LE(p->y(), 99);
+      }
+    }
+  }
+}
+
+TEST(MapWidgetToImagePixel, FrameDownscaledFromImageStillMaps)
+{
+  // Image 800×600 displayed at 80×60 (downscaled 10×); cursor at frame (8, 6)
+  // lands at exactly (80, 60) by direct proportion (no rounding involved).
+  const auto p = mapWidgetToImagePixel(8, 6, 80, 60, 800, 600, 0);
+  ASSERT_TRUE(p.has_value());
+  EXPECT_EQ(p->x(), 80);
+  EXPECT_EQ(p->y(), 60);
+}


### PR DESCRIPTION
## Proposed user-facing changes

This PR adds a UI status strip below the image showing image resolution and encoding (as received from the ROS message), receive framerate as well as the pixel value under the mouse cursor (mirroring the new RViz behavior introduced by https://github.com/ros2/rviz/pull/1716). The bar's presence is toggled using the new light bulb button in the top bar, and by default it's hidden (keeping in line with existing behavior). These changes partially address the desired features raised in https://github.com/ros-visualization/rqt_image_view/issues/1 (that issue also mentions the desire to show bandwidth, which we don't do here).

Screenshot of the new situation:

<img width="532" height="559" alt="Screenshot from 2026-05-23 20-29-59" src="https://github.com/user-attachments/assets/66323b23-6886-4faf-9d03-7a793240d3b9" />

## Implementation notes
### Code
Please see the commit message. TBH the diff got far larger than I expected, part of the reason for that is that I chose to support some rarely used image encodings, made sure some edge cases are handled properly (for example: the cursor-to-message pixel mapping remains correct when one rotates the image after the image publisher stopped publishing) and also added several tests. That said, suggestions to decrease the diff are always appreciated.

### Supported encodings
For reference, here's a comparison table of how particular encodings are handled, for both this PR and for RViz:
| Encoding | This PR | rviz #1716 |
  |---|---|---|
  | `MONO8` / `8UC1` | decoded → `value:N` | decoded → `mono:N` |
  | `MONO16` / `16UC1` | decoded → `value:N` | decoded → `mono16:N` |
  | `TYPE_32FC1` | decoded → `value:N` | decoded → `value:N` |
  | `RGB8` | decoded → R/G/B coloured | decoded → R/G/B coloured |
  | `BGR8` | decoded → R/G/B coloured | decoded → R/G/B coloured |
  | `RGBA8` | decoded → R/G/B/A coloured | decoded → R/G/B/A coloured |
  | `BGRA8` | decoded → R/G/B/A coloured | decoded → R/G/B/A coloured |
  | `RGB16` | decoded → R/G/B coloured | raw hex |
  | `BGR16` | decoded → R/G/B coloured | raw hex |
  | `RGBA16` | decoded → R/G/B/A coloured | raw hex |
  | `BGRA16` | decoded → R/G/B/A coloured | raw hex |
  | `8UC2`/`8UC3`/`8UC4`, `16UC2-4`, `32FC2-4` | raw hex (sensor_msgs-derived stride) | raw hex (step-derived stride) |
  | Bayer variants (`bayer_rggb8`, `bayer_bggr8`, …) and 16-bit counterparts | raw hex (sensor_msgs-derived stride) | raw hex
  (step-derived stride) |
  | YUV / planar formats (`yuv422`, etc.) | raw hex (step-derived stride) | raw hex (step-derived stride) |
  | Unknown encoding, no step→`width`-derivable stride | `(unsupported)` | `(unsupported)` |
  | Big-endian message on multi-byte channel | raw hex (endianness gate) | decoded as host-endian (mis-decode risk) |

## Use of generative AI
Claude Opus 4.7

## Questions
I'm aware that this large change may not be that desirable for a small codebase that hasn't seen that much change in the past decade. And while I'd definitely want to see this feature getting merged, I also don't want to overload the maintainers. I'm open to discussing how we best handle this.