### PR TITLE
Remove Qt5 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,8 +25,7 @@ endif()
 find_package(rclcpp REQUIRED)
 
 find_package(qt_gui_cpp REQUIRED)
-set(QT_VERSION_MAJOR "${qt_gui_cpp_USE_QT_MAJOR_VERSION}")
-find_package(Qt${qt_gui_cpp_USE_QT_MAJOR_VERSION} REQUIRED COMPONENTS Widgets Core)
+find_package(Qt6 REQUIRED COMPONENTS Widgets Core)
 
 find_package(rqt_gui_cpp REQUIRED)
 find_package(image_transport REQUIRED)
@@ -34,8 +33,6 @@ find_package(sensor_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(cv_bridge REQUIRED)
 find_package(ament_cmake_python REQUIRED)
-
-message("Using Qt ${QT_VERSION_MAJOR}")
 
 set(rqt_image_view_SRCS
   src/rqt_image_view/detail/framerate_estimator.cpp
@@ -54,13 +51,8 @@ set(rqt_image_view_UIS
   src/rqt_image_view/image_view.ui
 )
 
-if(${QT_VERSION_MAJOR} GREATER "5")
-  qt_wrap_cpp(rqt_image_view_MOCS ${rqt_image_view_HDRS})
-  qt_wrap_ui(rqt_image_view_UIS_H ${rqt_image_view_UIS})
-else()
-  qt5_wrap_cpp(rqt_image_view_MOCS ${rqt_image_view_HDRS})
-  qt5_wrap_ui(rqt_image_view_UIS_H ${rqt_image_view_UIS})
-endif()
+qt_wrap_cpp(rqt_image_view_MOCS ${rqt_image_view_HDRS})
+qt_wrap_ui(rqt_image_view_UIS_H ${rqt_image_view_UIS})
 
 add_library(${PROJECT_NAME} SHARED
   ${rqt_image_view_SRCS}
@@ -80,9 +72,9 @@ target_link_libraries(${PROJECT_NAME} PUBLIC
   image_transport::image_transport
   ${sensor_msgs_TARGETS}
   ${geometry_msgs_TARGETS}
-  Qt${QT_VERSION_MAJOR}::Widgets
+  Qt6::Widgets
 PRIVATE
-  Qt${QT_VERSION_MAJOR}::Core
+  Qt6::Core
   cv_bridge::cv_bridge
 )
 

--- a/package.xml
+++ b/package.xml
@@ -19,8 +19,8 @@
   <build_depend>cv_bridge</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>image_transport</build_depend>
-  <build_depend>qt-base-dev</build_depend>
-  <build_depend>libqtwidgets</build_depend>
+  <build_depend>qt6-base-dev</build_depend>
+  <build_depend>libqt6-widgets</build_depend>
   <build_depend>rqt_gui</build_depend>
   <build_depend>rqt_gui_cpp</build_depend>
   <build_depend>qt_gui_cpp</build_depend>
@@ -29,8 +29,8 @@
   <exec_depend>cv_bridge</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>image_transport</exec_depend>
-  <exec_depend>qt-base-dev</exec_depend>
-  <exec_depend>libqtwidgets</exec_depend>
+  <exec_depend>qt6-base-dev</exec_depend>
+  <exec_depend>libqt6-widgets</exec_depend>
   <exec_depend>rqt_gui</exec_depend>
   <exec_depend>rqt_gui_cpp</exec_depend>
   <exec_depend>qt_gui_cpp</exec_depend>

--- a/src/rqt_image_view/image_view.cpp
+++ b/src/rqt_image_view/image_view.cpp
@@ -166,17 +166,11 @@ void ImageView::initPlugin(qt_gui_cpp::PluginContext & context)
   connect(ui_.rotate_right_push_button, SIGNAL(clicked(bool)), this, SLOT(onRotateRight()));
 
   // Make sure we have enough space for "XXX °"
-#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
   // QFontMetrics::width(QChar) is deprecated starting from qt version 5.11.0
   // https://doc.qt.io/qt-5/qfontmetrics.html#horizontalAdvance-1
   ui_.rotate_label->setMinimumWidth(
     ui_.rotate_label->fontMetrics().horizontalAdvance("XXX°")
   );
-#else
-  ui_.rotate_label->setMinimumWidth(
-    ui_.rotate_label->fontMetrics().width("XXX°")
-  );
-#endif
 
   hide_toolbar_action_ = new QAction(tr("Hide toolbar"), this);
   hide_toolbar_action_->setCheckable(true);
@@ -197,15 +191,9 @@ void ImageView::setupInfoBar()
   // padded numbers (framerate, hover coords, channel values) stay column-
   // aligned and do not shift neighbours as values change magnitude.
   ui_.info_bar_widget->setFont(QFontDatabase::systemFont(QFontDatabase::FixedFont));
-#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
   ui_.framerate_label->setMinimumWidth(
     ui_.framerate_label->fontMetrics().horizontalAdvance(FRAMERATE_SIZING_SAMPLE)
   );
-#else
-  ui_.framerate_label->setMinimumWidth(
-    ui_.framerate_label->fontMetrics().width(FRAMERATE_SIZING_SAMPLE)
-  );
-#endif
   connect(ui_.info_bar_toggle_button, SIGNAL(toggled(bool)), this,
       SLOT(onInfoBarToggled(bool)));
   connect(ui_.image_frame, SIGNAL(mouseMovedOnImage(int,int)), this,  // NOLINT


### PR DESCRIPTION
This is needed after Qt5 removal from qt_gui_core in https://github.com/ros-visualization/qt_gui_core/pull/345. Variable `qt_gui_cpp_USE_QT_MAJOR_VERSION` was removed, which causes this package build failure.